### PR TITLE
Pluginify shim should allow callback to be optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ bower_components
 test/out/
 test/bundle/bundles/
 test/pluginify/out.js
+test/nocallback/out.js
 test/dep_plugins/bundles
 test/bundles/
 test/other_bundle/other_dist/

--- a/lib/build/pluginifier.js
+++ b/lib/build/pluginifier.js
@@ -21,8 +21,6 @@ var toss = function(e){
 	},1);
 };
 
-
-
 var pluginifier = function(config, pluginifierOptions){
 	pluginifierOptions = _.assign(pluginifierOptions||{}, {
 		useNormalizedDependencies: true

--- a/lib/bundle/add_global_shim.js
+++ b/lib/bundle/add_global_shim.js
@@ -66,7 +66,7 @@ var shim = function(exports, global){
 		}
 
 		global.define = origDefine;
-		var result = callback.apply(null, args);
+		var result = callback ? callback.apply(null, args) : undefined;
 		global.define = ourDefine;
 
 		// Favor CJS module.exports over the return value

--- a/test/nocallback/index.html
+++ b/test/nocallback/index.html
@@ -1,0 +1,1 @@
+<script src="out.js"></script>

--- a/test/nocallback/nocallback.js
+++ b/test/nocallback/nocallback.js
@@ -1,0 +1,1 @@
+steal('nocallback/other.js');

--- a/test/nocallback/other.js
+++ b/test/nocallback/other.js
@@ -1,0 +1,5 @@
+steal(function() {
+	window.RESULT = {
+		message: "I worked!"
+	};
+});

--- a/test/test.js
+++ b/test/test.js
@@ -767,6 +767,27 @@ describe("pluginify", function(){
 
 
 	});
+
+	it("works when a file has no callback", function(done) {
+		pluginify({
+			config: __dirname + "/stealconfig.js",
+			main: "nocallback/nocallback"
+		}, {
+			exports: {},
+			quiet: true
+		}).then(function(pluginify) {
+			fs.writeFile(__dirname+"/nocallback/out.js", pluginify(), function(err) {
+			    // open the prod page and make sure
+				// the plugin processed the input correctly
+				open("test/nocallback/index.html", function(browser, close){
+					find(browser, "RESULT", function(result){
+						assert(result.message, "I worked!");
+						close();
+					}, close);
+				}, done);
+			});
+		});
+	});
 });
 
 describe("multi-main", function(){


### PR DESCRIPTION
This is valid AMD:

``` js
define('module', ['dep1']);
```

But our shim [assumes there will be a callback](https://github.com/bitovi/steal-tools/blob/master/lib/build/pluginifier.js#L39)

I'll write a test and fix for this.
