### PR TITLE
This makes pluginify play nicely with other AMD loaders

### DIFF
--- a/lib/build/pluginifier.js
+++ b/lib/build/pluginifier.js
@@ -16,6 +16,8 @@ var toss = function(e){
 };
 
 var shim = function(exports, global){
+	var origDefine = global.define;
+
 	var get = function(name){
 		var parts = name.split("."),
 			cur = global,
@@ -26,7 +28,7 @@ var shim = function(exports, global){
 		return cur;
 	};
 	var modules = global.define && global.define.modules || {};
-	global.define = function(moduleName, deps, callback){
+	var ourDefine = global.define = function(moduleName, deps, callback){
 		var module;
 		if(typeof deps === "function") {
 			callback = deps;
@@ -45,7 +47,11 @@ var shim = function(exports, global){
 			};
 			args.push(require, module.exports, module);
 		}
+
+		global.define = origDefine;
 		var result = callback.apply(null, args);
+		global.define = ourDefine;
+
 		// Favor CJS module.exports over the return value
 		modules[moduleName] = module && module.exports ? module.exports : result;
 	};
@@ -85,14 +91,14 @@ var pluginifier = function(config, pluginifierOptions){
 			var ignores = pluginifier.getAllIgnores(options.ignore, data.graph);
 			var nodesInBundle = pluginifier.notIgnored(nodes, ignores);
 			
-			var shim = pluginifier.shim(nodesInBundle, exports);
+			var shim = pluginifier.shim(nodes, exports);
 			
 			var bundle = {nodes: nodesInBundle};
 			concatSource(bundle,"transpiledSource");
 
 			// If the user wants to keep dev tags like steal-remove-start
 			if(options.keepDevTags) {
-				return shim+"\n"+bundle.source;
+				return shim + "\n" + bundle.source;
 			} else {
 				return shim + "\n" + clean(bundle.source, {});
 			}


### PR DESCRIPTION
This change makes pluginify play nicely with other AMD loaders by
setting the original `define` back onto global before executing the
callbacks.
