### PR TITLE
Fixed typo in flatten.js

### DIFF
--- a/lib/bundle/flatten.js
+++ b/lib/bundle/flatten.js
@@ -31,7 +31,7 @@ var bundle = {
 			var lower = shares[min.lower],
 				upper = shares[min.higher];
 
-			winston.debug("  flattening "+name.getName(upper.bundles)+">"+name.getName(lower.bundles));
+			winston.debug("  flattening "+name.getName(upper)+">"+name.getName(lower));
 			
 			for(var appName in min.diff.bundleToWaste){
 				if( min.diff.bundleToWaste[appName] ){


### PR DESCRIPTION
Looks like a bad argument for `getName(bundle)`, should be a `bundle`, not `bundle.bundles`. Without the fix, `getName()` raises an error when it does `var bundleNames = bundle.bundles.map(...)`.
