### PR TITLE
flatten: Fix undefined error

### DIFF
--- a/lib/bundle/flatten.js
+++ b/lib/bundle/flatten.js
@@ -1,6 +1,7 @@
 // flattens a bundle graph
 var winston = require('winston');
 var name = require('./name');
+var size = require('../node/size');
 var bundle = {
 		/**
 		 * Flattens the list of shares until each script has a minimal depth
@@ -141,7 +142,7 @@ var bundle = {
 				nodes.forEach(function(node){
 					// check file's appName
 					if(node.bundles.indexOf(appName) == -1){
-						diff.bundleToWaste[appName] += node.minifiedSource.length;
+						diff.bundleToWaste[appName] += size(node);
 					}
 				});
 				diff.totalWaste += diff.bundleToWaste[appName];


### PR DESCRIPTION
Without this change, running `grunt build` would generate this error:

```
...
Transpiling...
Minifying...
Calculating main bundle(s)...
Flattening main bundle(s)...
ERROR: Cannot read property 'length' of undefined TypeError: Cannot read property 'length' of undefined
    at /Users/alvin/Projects/mathspace/www/msproblem/static/jsmvc/node_modules/steal-tools/lib/bundle/flatten.js:144:47
...
```

It seems that sometimes `node.minifiedSource` can be undefined, and that there's `node/source`  and `node/size` functions that can better handle this.
