### PR TITLE
Exclude plugins for global pluginified files

### DIFF
--- a/lib/build/pluginifier.js
+++ b/lib/build/pluginifier.js
@@ -108,7 +108,7 @@ var pluginifier = function(config, pluginifierOptions){
 			bundle.nodes.forEach(function(node) {
 				winston.debug("+ %s", node.load.name);
 			});
-			concatSource(bundle,"activeSource");
+			concatSource(bundle,"activeSource", options.format === "global");
 			
 			return bundle.source;
 		};

--- a/lib/bundle/concat_source.js
+++ b/lib/bundle/concat_source.js
@@ -1,11 +1,13 @@
 var source = require('../node/source');
 
-module.exports = function(bundle, sourceProp){
+module.exports = function(bundle, sourceProp, excludePlugins){
 	bundle.source = "";
 	bundle.nodes.forEach(function(node){
 		bundle.source += "/*"+node.load.name+"*/\n";
 		if(node.isPlugin && !node.value.includeInBuild) {
-			bundle.source += "System.set('"+node.load.name+"', System.newModule({}));\n";
+			if(!excludePlugins) {
+				bundle.source += "System.set('"+node.load.name+"', System.newModule({}));\n";
+			}
 		} else {
 			bundle.source += source(node, sourceProp)+"\n";
 		}

--- a/test/test.js
+++ b/test/test.js
@@ -810,6 +810,23 @@ describe("pluginify", function(){
 			});
 		});
 	});
+
+	it("Excludes plugins from the built output unless marked includeInBuild", function(done){
+		pluginify({
+			config: __dirname+"/plugins/config.js",
+			main: "main"
+		}, {
+			exports: {},
+			quiet: true
+		}).then(function(pluginify){
+			var pluginOut = pluginify(null, {
+				minify: false
+			});
+
+			assert.equal(/System\.set/.test(pluginOut), false,
+						 "No System.set in the output");
+		}).then(done);
+	});
 });
 
 describe("multi-main", function(){


### PR DESCRIPTION
This adds an option to concatSource to allow the exclusion of plugins from the bundle.source. This is necessary because o plugins that are not meant to be included in the build, a `System.set` call is added which will not work for global pluginified outputs. Fixes #42
