### PR TITLE
Fixes for multi build errors

### DIFF
--- a/lib/bundle/flatten.js
+++ b/lib/bundle/flatten.js
@@ -32,7 +32,7 @@ var bundle = {
 			var lower = shares[min.lower],
 				upper = shares[min.higher];
 
-			winston.debug("  flattening "+name.getName(upper.bundles)+">"+name.getName(lower.bundles));
+			winston.debug("  flattening "+name.getName(upper)+">"+name.getName(lower));
 			
 			for(var appName in min.diff.bundleToWaste){
 				if( min.diff.bundleToWaste[appName] ){


### PR DESCRIPTION
This fixes a couple of problems I encountered during the building of our project. One was getting the `size` of a node, of which there is `bundle/size` for that, the other was the logging that was using `name.getName` which expects the bundle itself. We probably need a test for `name`.
