### PR TITLE
Prevent swallowing of errors

### DIFF
--- a/lib/build/multi.js
+++ b/lib/build/multi.js
@@ -194,5 +194,6 @@ module.exports = function(config, options){
 		
 	}).catch(function(e){
 		winston.error(e.message, e.stack);
+		throw e;
 	});
 };

--- a/test/test.js
+++ b/test/test.js
@@ -468,6 +468,28 @@ describe("multi build", function(){
 		});
 	
 	});
+
+
+	it("Returns an error when building a main that doesn\'t exist", function(done){
+		var config = {
+			config: __dirname + "/stealconfig.js",
+			main: "some/fake/app"
+		};
+
+		var options = {
+			quiet: true
+		};
+
+		multiBuild(config, options).then(function onFulfilled(){
+			// If we get then the error wasn't caught properly
+			assert(false, "Build completed successfully when there should have been an error");
+			done();
+		}, function onRejected(err){
+			assert(err instanceof Error, "Caught an error when loading a fake main");
+			done();
+		});
+
+	});
 });
 
 describe("multi build with plugins", function(){


### PR DESCRIPTION
Previously we were swallowing errors that occurred during the multi-build process. This adds a test of what happens when we try to load a module that doesn't exist. The result should be that the promise is rejected, bubbling all the way up to the user. This fixes it. Fixes #22 
