### PR TITLE
Remove development code in the multi-build

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -48,6 +48,7 @@ progressively loaded.
 for any `bundle` module.
 @option {Number} [mainDepth=3] The maximum number of bundles that will be loaded for any `main`
 module.
+@option {Boolean} [removeDevelopmentCode=true] Remove any development code from the bundle specified using `//!steal-remove-start` and `//!steal-remove-end` comments.
 
 
 @return {{}}

--- a/lib/build/multi.js
+++ b/lib/build/multi.js
@@ -75,6 +75,7 @@ var makeBundleGraph = require("../graph/make_graph_with_bundles"),
 	_ = require("lodash"),
 	logging = require("../logger"),
 	hasES6 = require("../graph/has_es6"),
+	clean = require("../graph/clean"),
 	addTraceurRuntime = require("../bundle/add_traceur_runtime"),
 	makeConfiguration = require("../configuration/make"),
 	splitGraphByModuleNames = require("../graph/split"),
@@ -83,7 +84,8 @@ var makeBundleGraph = require("../graph/make_graph_with_bundles"),
 module.exports = function(config, options){
 	options = _.assign({ // Defaults
 		minify: true,
-		bundleSteal: false
+		bundleSteal: false,
+		removeDevelopmentCode: true
 	}, options);
 
 	// Setup logging
@@ -116,6 +118,11 @@ module.exports = function(config, options){
 		( data.loader.bundle || []).forEach(function(moduleName){
 			order(dependencyGraph, moduleName);
 		});
+
+		// Clean development code if the option was passed
+		if(options.removeDevelopmentCode) {
+			clean(dependencyGraph, options);
+		}
 		
 		// Transpile each module to amd. Eventually, production builds
 		// should be able to work without steal.js.

--- a/test/bundle/app_a.js
+++ b/test/bundle/app_a.js
@@ -1,7 +1,13 @@
 define(['dep_a_b', 'dep_all'], function(ab, all){
-	return {
+	var mod = {
 		name: "a",
 		ab: ab,
 		all: "all"
 	};
+	
+	//!steal-remove-start
+	mod.clean = false
+	//!steal-remove-end
+
+	return mod;
 });

--- a/test/test.js
+++ b/test/test.js
@@ -212,10 +212,11 @@ describe("multi build", function(){
 			}).then(function(data){
 				open("test/bundle/bundle.html#a",function(browser, close){
 					find(browser,"appA", function(appA){
-							assert(true, "got A");
-							assert.equal(appA.name, "a", "got the module");
-							assert.equal(appA.ab.name, "a_b", "a got ab");
-							close();
+						assert(true, "got A");
+						assert.equal(appA.name, "a", "got the module");
+						assert.equal(appA.ab.name, "a_b", "a got ab");
+						assert.equal(appA.clean, undefined, "removed dev code");
+						close();
 					}, close);
 				}, done);
 


### PR DESCRIPTION
This adds the ability to remove development code from the multi-build
using the same configuration option provided by pluginify. Fixes #67
