### PR TITLE
Fixes error reporting test

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -461,9 +461,7 @@ describe("multi build", function(){
 				}, done);
 
 
-			}).catch(function(e){
-				done(e);
-			});
+			}, done);
 
 
 
@@ -482,26 +480,30 @@ describe("multi build", function(){
 			quiet: true
 		};
 
+		// Temporarily swallow console.logs to prevent 404 showing.
+		var log = console.log;
+		console.log = function(){};
+
 		multiBuild(config, options).then(function onFulfilled(){
 			// If we get then the error wasn't caught properly
 			assert(false, "Build completed successfully when there should have been an error");
-			done();
 		}, function onRejected(err){
 			assert(err instanceof Error, "Caught an error when loading a fake main");
-			done();
-		});
+		}).then(function() {
+			// Set back console.log
+			console.log = log;
+		}).then(done);
 
 	});
 });
 
 describe("multi build with plugins", function(){
 	it("work on the client", function(done){
-
 		open("test/plugins/site.html", function(browser, close){
 
 			find(browser,"PLUGTEXT", function(plugText){
-					assert.equal(plugText, "client-Holler", "client can do plugins");
-					close();
+				assert.equal(plugText, "client-Holler", "client can do plugins");
+				close();
 			}, close);
 
 		}, done);


### PR DESCRIPTION
Fixes a test that reports an error when attempting to build a module
that isn't in the filesystem. Test was working fine but because Steal
does a console.log on errors it was sending a File Not Found message
into the console that could be misinterpreted. Fix is to swallow
console.logs during the running of the test and set it back afterwards.
