### PR TITLE
Windows paths bundles config bug fix

### DIFF
--- a/lib/bundle/make_bundles_config.js
+++ b/lib/bundle/make_bundles_config.js
@@ -38,7 +38,9 @@ function getBundlesPaths(configuration){
 	if(!configuration.loader.bundlesPath) {
 		return "";
 	}
-	var bundlesPath = configuration.bundlesPathURL;
+	
+	// Replace back slash in windows paths
+	var bundlesPath = configuration.bundlesPathURL.replace(/\\/g, '/');
 
 	// Get the dist directory and set the paths output
 	var paths = util.format('System.paths["bundles/*.css"] ="%s/*css";\n' +


### PR DESCRIPTION
Replace back slash in windows paths in bundles config to address this issue https://github.com/bitovi/steal-tools/issues/61
