### PR TITLE
Fix resloving traceruRuntime path on windows

### DIFF
--- a/lib/bundle/add_traceur_runtime.js
+++ b/lib/bundle/add_traceur_runtime.js
@@ -5,7 +5,7 @@ var fs = require('fs'),
 	minify = require("../graph/minify");
 	
 module.exports = function(bundle){
-	var lastTraceur = traceurPath.indexOf("traceur/");
+	var lastTraceur = traceurPath.indexOf("traceur");
 	var baseTraceur = traceurPath.substr(0, lastTraceur);
 	
 	// We have to product Steal's system.


### PR DESCRIPTION
https://github.com/bitovi/steal-tools/issues/95

I think removal of the slash and searching last occurrence of just "tracerur" should not break anything, it seems to be the simplest way.
