### PR TITLE
Only include Traceur runtime if used

### DIFF
--- a/lib/build/multi.js
+++ b/lib/build/multi.js
@@ -99,7 +99,6 @@ module.exports = function(config, options){
 		var dependencyGraph = data.graph,
 			// the apps we are building
 			mains = Array.isArray( config.main ) ? config.main.slice(0) : [data.loader.main],
-			hasES6modules = hasES6(dependencyGraph),
 			configuration = makeConfiguration(data.loader, data.buildLoader, options);
 
 		// Remove @config so it is not transpiled.  It is a global,
@@ -193,6 +192,7 @@ module.exports = function(config, options){
 				addStealToBundle(mainJSBundle, mainJSBundle.bundles[0], configuration);
 			}
 			// Traceur code requires a runtime.
+			var hasES6modules = hasES6(dependencyGraph);
 			if( hasES6modules ) {
 				addTraceurRuntime(mainJSBundle);
 			}

--- a/lib/graph/has_es6.js
+++ b/lib/graph/has_es6.js
@@ -1,5 +1,8 @@
+var source = require("../node/source");
+
 var isES6 = function(node){
-	return !node.load.metadata.format || node.load.metadata.format == 'es6';
+	var nodeSource = source(node) || "";
+	return nodeSource.indexOf("$traceurRuntime") >= 0;
 };
 
 

--- a/test/simple-es6/config.js
+++ b/test/simple-es6/config.js
@@ -1,0 +1,1 @@
+System.map.dep = "other";

--- a/test/simple-es6/main.js
+++ b/test/simple-es6/main.js
@@ -1,0 +1,1 @@
+import dep from "dep";

--- a/test/simple-es6/other.js
+++ b/test/simple-es6/other.js
@@ -1,0 +1,1 @@
+export default p = "other";

--- a/test/test.js
+++ b/test/test.js
@@ -252,6 +252,28 @@ describe("multi build", function(){
 		});
 	});
 
+	it("doesn't include the traceur runtime if it's not being used", function(done){
+		rmdir(__dirname + "/simple-es6/dist", function(error){
+			if(error) {
+				return done(error);
+			}
+
+			multiBuild({
+				config: __dirname + "/simple-es6/config.js",
+				main: "main"
+			}, {
+				quiet: true
+			}).then(function(){
+				fs.readFile(__dirname + "/simple-es6/dist/bundles/main.js", function(error, contents){
+					assert.equal(error, null, "Able to open the file");
+					assert.equal(/\$traceurRuntime/.test(contents), false, 
+								 "Traceur not included");
+					done();
+				});
+			}).catch(done);
+		});
+	});
+
 	it("Should minify by default", function(done){
 		var config = {
 			config: __dirname + "/minify/config.js",


### PR DESCRIPTION
This changes, based on the new version of Traceur, to only include the
runtime if the source is using the runtime. Because the runtime no
longer uses the `assertObject` calls it used to, for simple scenarios
such as only importing/exporting the runtime is not needed. This changes
`has_es6` to instead of testing the format, test for the presence of
`$traceurRuntime` in the source. Fixes #75 and #99
