### PR TITLE
Use the latest Steal minor branch

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "steal-tools",
   "version": "0.1.0",
   "devDependencies": {
-    "steal": "bitovi/steal#d1451bcdefa76caa3a513b77b784079f40967efe",
+    "steal": "bitovi/steal#3bed4ad03326bda1891e61b3cc5a791e3e114810",
     "jquery": "~1.10.0",
 	"less" : "^1.7.0"
   }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean-css": "2.1.8",
     "colors": "^0.6.2",
     "lodash": "2.4.1",
-    "steal": "git://github.com/bitovi/steal#d1451bcdefa76caa3a513b77b784079f40967efe",
+    "steal": "git://github.com/bitovi/steal#3bed4ad03326bda1891e61b3cc5a791e3e114810",
     "traceur": "0.0.58",
     "transpile": "git://github.com/bitovi/transpile#d8a3b000ee8e493e97fae253d48c5b2bbe2757eb",
     "uglify-js": "~2.4.13",


### PR DESCRIPTION
This upgrades us to the latest Steal minor branch which had a couple of bug fixes that shouldn't cause any problems.
