### PR TITLE
Reset window.define before evaling in pluginify

### DIFF
--- a/lib/bundle/add_global_shim.js
+++ b/lib/bundle/add_global_shim.js
@@ -75,7 +75,9 @@ var shim = function(exports, global){
 	global.define.modules = modules;
 	global.System = {
 		define: function(__name, __code){
+			global.define = origDefine;
 			eval(__code);
+			global.define = ourDefine;
 		}
 	};
 };

--- a/test/pluginify/global.js
+++ b/test/pluginify/global.js
@@ -1,0 +1,11 @@
+(function(global) {
+
+	global.globalModule = "This is a global module";
+
+	if(typeof define === "function") {
+		define(function() {
+			return global.globalModule;
+		});
+	}
+
+})(window);

--- a/test/pluginify/pluginify.js
+++ b/test/pluginify/pluginify.js
@@ -1,9 +1,10 @@
-steal('basics/module', './common.js', function(module, cjs){
+steal('basics/module', './common.js', './global.js', function(module, cjs, global){
 	
 	window.RESULT = {
 		name: "pluginified",
 		module: module,
-		cjs: cjs
+		cjs: cjs,
+		global: global
 	};
 
 	

--- a/test/stealconfig.js
+++ b/test/stealconfig.js
@@ -8,6 +8,12 @@ if(typeof window === "undefined" || window.noConfig !== true)  {
 		},
 		map: {
 			"mapd/mapd": "map/mapped"
+		},
+		meta: {
+			"pluginify/global": {
+				format: "global",
+				exports: "globalModule"
+			}
 		}
 	});
 

--- a/test/test.js
+++ b/test/test.js
@@ -713,7 +713,9 @@ describe("pluginify", function(){
 			config: __dirname+"/stealconfig.js",
 			main: "pluginify/pluginify"
 		}, {
-			exports: {},
+			exports: {
+				'pluginify/global': 'globalModule'
+			},
 			quiet: true
 		}).then(function(pluginify){
 
@@ -726,6 +728,7 @@ describe("pluginify", function(){
 					find(browser,"RESULT", function(result){
 						assert(result.module.es6module, "have dependeny");
 						assert(result.cjs(), "cjs");
+						assert.equal(result.global, "This is a global module", "Global module loaded");
 						close();
 					}, close);
 


### PR DESCRIPTION
Our System.define shim needs to have the same logic as our AMD shim.
That is, before executing code remove our `window.define` and replace it
with the original version, and then set back to our version after the
eval. This causes problems with "bad AMD". That is AMD that has it's
define statement at the bottom and therefore must be marked as a global.
Fixes #73
