### PR TITLE
Show file size of bundles in verbose mode

### DIFF
--- a/lib/bundle/write_bundles.js
+++ b/lib/bundle/write_bundles.js
@@ -19,12 +19,6 @@ module.exports = function(bundles, configuration) {
 
   bundles.forEach(function(bundle) {
     builtBundleDeferreds.push(new Promise(function(resolve, reject) {
-      winston.info("BUNDLE: %s", bundleFilename(bundle));
-
-      bundle.nodes.forEach(function(node) {
-        winston.info("+ %s", node.load.name);
-      });
-
       var bundlePath = bundlesDir + "" + bundleFilename(bundle);
 
       // Adjusts URLs
@@ -32,6 +26,14 @@ module.exports = function(bundles, configuration) {
 
       // Combines the source
       concatSource(bundle);
+	  
+      // Log the bundles
+      winston.info("BUNDLE: %s", bundleFilename(bundle));
+      winston.debug(Buffer.byteLength(bundle.source, "utf8") + " bytes");
+
+      bundle.nodes.forEach(function(node) {
+        winston.info("+ %s", node.load.name);
+      });
 
       // Once a folder has been created, write out the bundle source
       bundleDirDef.then(function() {


### PR DESCRIPTION
If verbose mode is enabled, output the file size as part of writing out
the bundles. Fixes #56

![d4348304-3955-11e4-99a9-88679caa46b2](https://cloud.githubusercontent.com/assets/361671/4656761/3c58eac2-54dd-11e4-8b52-97e276c78c20.png)
