### PR TITLE
Improve documentation for pluginify grunt task

### DIFF
--- a/doc/build-options.md
+++ b/doc/build-options.md
@@ -1,0 +1,16 @@
+@typedef {{}} stealTools.buildOptions buildOptions
+@description Options used throughout the build process.
+
+@option {Boolean} [minify=true] Whether the source code is minified prior to writing.
+
+@option {Boolean} [bundleSteal=false] Whether StealJS will be included in the built file. Enabling this option will allow you to limit the initial request to just one script.
+
+@option {Boolean} [removeDevelopmentCode=true] Whether development code (code wrapped with `@steal-remove-{start/stop}`) will be removed.
+
+@option {Array<String>} ignore Specify modules to not include in the final output. For example if you wanted to load jQuery from a cdn you would provide this option:
+
+    {
+      ignore: [ "jquery" ]
+    }
+
+@option {stealTools.format} format Specifies a format to transpile the dependency graph to. In the multiBuild all code is automatically transpiled to **amd** format. In [stealTools.pluginify] the default is to **global**.

--- a/doc/grunt-build.md
+++ b/doc/grunt-build.md
@@ -10,7 +10,7 @@ The `stealBuild` options object values.
 most other __build__ configuration values are specified in
 by [System.buildConfig] in the config file.
 
-@option {Object} buildOptions Specifies the `options` argument in [stealTool.build].
+@option {Object} buildOptions Specifies the `options` argument in [stealTools.build].
 
 
 @body

--- a/doc/grunt-pluginify-task.md
+++ b/doc/grunt-pluginify-task.md
@@ -1,0 +1,8 @@
+@typedef {{}} stealTools.grunt.pluginify.task task
+@description A task of the [stealTools.grunt.pluginify pluginify] grunt task.
+
+@option {Object} system Specifies the [System.config] values used to load modules.
+
+@option {Object} options Options for the pluginify task such as minification.
+
+@option {stealTools.grunt.pluginify.output} outputs Configures output files to be written.

--- a/doc/grunt-pluginify.md
+++ b/doc/grunt-pluginify.md
@@ -1,14 +1,15 @@
-@function stealTools.grunt.pluginify stealPluginify
+@typedef {{}} stealTools.grunt.pluginify stealPluginify
 @parent steal-tools.grunt 
 
 Write out modules that are optionally transpiled, minified, and bundled.
+
+@option {Object<stealTools.grunt.pluginify.task>} tasks Specify pluginify tasks with their own set of `system`, `options`, and [stealTools.grunt.pluginify.output outputs].
 
 @body
 
 ## Use
 
-`stealPluginify` is a grunt [multi-task](http://gruntjs.com/creating-tasks#multi-tasks). This means that to
-build output 
+`stealPluginify` is a grunt [multi-task](http://gruntjs.com/creating-tasks#multi-tasks) that is used to build library projects to a variety of formats. This means that to build output 
 
     grunt.initConfig({
       stealPluginify: {
@@ -31,11 +32,20 @@ Each `stealPluginify` task is configured by three values:
 
 ## system
 
+These are [System.config] values that are used to load modules during the build process. Typically you will want to specify at least the `config` and `main` options like so:
+
+    {
+	  config: __dirname + "/config.js",
+      main: ["math/add", "math/subtract"]
+    }
+
 ## options
+
+Options are the [stealTools.buildOptions] used for configuration the behavior of the build, such as whether minification is turned on or not.
 
 ## outputs
 
-Outputs is an object names and ouput configuration objects.  Each configuration object contains 
+Outputs is an object names and [stealTools.grunt.pluginify.output output configuration] objects.  Each configuration object contains 
 
     {
       eachModule: [],


### PR DESCRIPTION
There was already some documentation in place, especially for `outputs`, but this adds more details and creates a separate `task` typedef for the pluginify tasks. Hopefully this explains the API, but we also need to add a guide I think. Fixes #82
