### PR TITLE
Fix command line docs.

### DIFF
--- a/doc/command-build.md
+++ b/doc/command-build.md
@@ -1,9 +1,9 @@
-@function stealTools.cmd.build stealTools build
+@function stealTools.cmd.build steal-tools build
 @parent steal-tools.cmd 
 
-Builds stealTools from the command line.
+Builds steal-tools from the command line.
 
-@signature `stealTools build [--OPTION_NAME OPTION_VALUE]...`
+@signature `steal-tools build [--OPTION_NAME OPTION_VALUE]...`
 
 @param {String} OPTION_NAME Any `config` or `options` name in [stealTools.build].
 
@@ -17,6 +17,6 @@ steal-tools must have been installed into the commandLine like:
 
     npm install steal-tools -g
     
-Then you can run `stealTools` like:
+Then you can run `steal-tools` like:
 
-    stealTools build --config app/config.js --main app/app
+    steal-tools build --config app/config.js --main app/app

--- a/doc/command-pluginify.md
+++ b/doc/command-pluginify.md
@@ -1,9 +1,9 @@
-@function stealTools.cmd.pluginify stealTools pluginify
+@function stealTools.cmd.pluginify steal-tools pluginify
 @parent steal-tools.cmd 
 
 Pluginifies a module from the command line.
 
-@signature `stealTools pluginify [--OPTION_NAME OPTION_VALUE]...`
+@signature `steal-tools pluginify [--OPTION_NAME OPTION_VALUE]...`
 
 @param {String} OPTION_NAME Any `config`, `pluginifierOptions` or `options` name in 
 [stealTools.pluginifier] or [stealTools.pluginify pluginify].
@@ -21,9 +21,9 @@ steal-tools must have been installed into the commandLine like:
 
     npm install steal-tools -g
     
-Then you can run `stealTools` like:
+Then you can run `steal-tools` like:
 
-    stealTools pluginify \
+    steal-tools pluginify \
                --config app/config.js \
                --main app \
                --ignores foo/.+


### PR DESCRIPTION
Replace `stealTools` by `steal-tools` (the actual command name).

Before:
![screen shot 2014-11-11 at 17 21 15](https://cloud.githubusercontent.com/assets/724877/5000105/375690d4-69c7-11e4-83ea-0369e5cc91bf.png)

After:
![screen shot 2014-11-11 at 17 22 23](https://cloud.githubusercontent.com/assets/724877/5000122/593459c0-69c7-11e4-8af9-ba0170a383f4.png)
