### PR TITLE
import @config prior to main in production

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "steal-tools",
   "version": "0.5.0",
   "devDependencies": {
-    "steal": "0.4.0",
+    "steal": "bitovi/steal#4379ddf9c78672226b8fe87c5a75f88b2ffdca5d",
     "jquery": "~1.10.0",
 	"less" : "^1.7.0"
   }

--- a/lib/build/multi.js
+++ b/lib/build/multi.js
@@ -89,7 +89,7 @@ module.exports = function(config, options){
 	}, options);
 
 	// Setup logging
-	logging.setup(options);
+	logging.setup(options, config);
 
 	// Minification is optional
 	var minify = options.minify = options.minify !== false;
@@ -169,7 +169,7 @@ module.exports = function(config, options){
 		
 		// Every mainBundle needs to have @config and bundle configuration to know
 		// where everything is. Lets get those main bundles here while there is less to go through.
-		
+
 		var mainJSBundles = mains.map(function(main){
 			return getBundleForOnly(splitMainBundles,main,"js");
 		});
@@ -178,14 +178,21 @@ module.exports = function(config, options){
 		var allBundles = splitMainBundles.concat(splitBundles);
 		// Name each bundle so we know what to call the bundle.
 		allBundles.forEach(nameBundle);
-		
-		
+
+		// Create a lookup object of the main bundle names so that they are
+		// excluded from the Bundles config
+		var mainJSBundleNames = {};
+		mainJSBundles.forEach(function(mainJSBundle){
+			mainJSBundleNames[mainJSBundle.name] = true;
+		});
 		
 		// Add @config and the bundleConfigNode to each main
 		mainJSBundles.forEach(function(mainJSBundle){
 			[].unshift.apply(mainJSBundle.nodes, stealconfig );
 			// Make config JS code so System knows where to look for bundles.
-			var configNode = makeBundlesConfig(allBundles, configuration, mainJSBundle );
+			var configNode = makeBundlesConfig(allBundles, configuration, mainJSBundle, {
+				excludedBundles: mainJSBundleNames
+			});
 			mainJSBundle.nodes.unshift(configNode);
 			
 			if(options.bundleSteal) {

--- a/lib/build/pluginifier.js
+++ b/lib/build/pluginifier.js
@@ -28,7 +28,7 @@ var pluginifier = function(config, pluginifierOptions){
 	pluginifierOptions.exports = pluginifierOptions.exports || {};
 
 	// Setup logging
-	logging.setup(pluginifierOptions);
+	logging.setup(pluginifierOptions, config);
 
 	return makeGraph(config, pluginifierOptions).then(function(data){
 

--- a/lib/bundle/add_steal.js
+++ b/lib/bundle/add_steal.js
@@ -5,5 +5,5 @@ var makeStealNode = require("../node/make_steal_node"),
 // makes it so this bundle loads steal
 module.exports = function(bundle, main, configuration){
 	bundle.nodes.unshift(makeNode("[production-config]","steal={env: 'production'};"), makeStealNode(configuration));
-	bundle.nodes.push( makeNode("[import-main-module]", "System.import('"+main+"');") );
+	bundle.nodes.push( makeNode("[import-main-module]", "System.import('@config').then(function() {\nSystem.import('"+main+"'); \n});") );
 };

--- a/lib/bundle/make_bundles_config.js
+++ b/lib/bundle/make_bundles_config.js
@@ -5,9 +5,11 @@ var util = require("util");
  * @param {Object} bundles
  * @param {Object} configuration
  * @param {Object} targetBundle the bundle this config is being built for.
+ * @param {Object} options Additional options to select what bundles to include.
  */
-module.exports = function(bundles, configuration, targetBundle){
+module.exports = function(bundles, configuration, targetBundle, options){
 	var paths = getBundlesPaths(configuration);
+	var excludedBundles = options.excludedBundles || {};
 	
 	var bundledBundles = bundles.slice(0);
 	if(configuration.options.bundleSteal){
@@ -17,8 +19,8 @@ module.exports = function(bundles, configuration, targetBundle){
 	var bundlesConfig = {};
 	bundledBundles.forEach(function(bundle){
 		// Don't write a bundles config for your own bundle.  Otherwise,
-		// inifinate recursion will happen.
-		if(targetBundle.name !== bundle.name) {
+		// inifinite recursion will happen.
+		if(targetBundle.name !== bundle.name && !excludedBundles[bundle.name]) {
 			bundlesConfig[bundle.name] = bundle.nodes.map(function(node){
 				return node.load.name;
 			});

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -65,12 +65,22 @@ function removeTransports(transports) {
 	});
 }
 
-exports.setup = function (config) {
+/**
+ * @param {Object} options Logging options passed from the user.
+ * @param {Object} config System configuration object.
+ */
+exports.setup = function (options, config) {
 	removeTransports([winston.transports.Console, StealTransport]);
 
 	winston.add(StealTransport, {
-		level: config.verbose ? 'debug' : 'info',
+		level: options.verbose ? 'debug' : 'info',
 		colorize: true,
-		silent: config.quiet && !config.verbose
+		silent: options.quiet && !options.verbose
 	});
+
+	if(options.quiet && config) {
+		config.logLevel = 3;
+	} else if(options.verbose && config) {
+		config.logLevel = 0;
+	}
 };

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -56,7 +56,7 @@ function getESModuleImports(load){
 }
 
 var trace = function(System, BuildSystem, onFulfilled, onRejected){
-	
+
 	System.pluginLoader = BuildSystem;
 	
 	// The BuildSystem loader will execute modules, but wait for the value to come through
@@ -92,7 +92,13 @@ var trace = function(System, BuildSystem, onFulfilled, onRejected){
 
 		var res = systemInstantiate.apply(this, arguments);
 
-		return Promise.resolve(res).then(function(instantiateResult){
+		return Promise.resolve(res).then(function fullfill(instantiateResult){
+			// If the config is a global mark it as cjs so that it will be converted
+			// to AMD by transpile. Needed because of this bug:
+			// https://github.com/ModuleLoader/es6-module-loader/issues/231
+			if(load.name === "@config" && load.metadata.format === "global") {
+				load.metadata.format = "cjs";
+			}
 
 			if(!instantiateResult) {
 				var imports = getESModuleImports(load);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean-css": "2.1.8",
     "colors": "^0.6.2",
     "lodash": "2.4.1",
-    "steal": "0.4.0",
+    "steal": "git://github.com/bitovi/steal.git#4379ddf9c78672226b8fe87c5a75f88b2ffdca5d",
     "traceur": "0.0.58",
     "transpile": "0.3.0",
     "uglify-js": "~2.4.13",

--- a/test/import-config/bundled.html
+++ b/test/import-config/bundled.html
@@ -1,0 +1,3 @@
+<script src="./dist/bundles/main.js"
+		data-base-url="./"
+		data-env="production"></script>

--- a/test/import-config/config.js
+++ b/test/import-config/config.js
@@ -1,0 +1,10 @@
+require("other");
+require("global");
+
+System.config({
+	meta: {
+		foo: {
+			exports: "bar"
+		}
+	}
+});

--- a/test/import-config/global.js
+++ b/test/import-config/global.js
@@ -1,0 +1,3 @@
+System.config({
+
+});

--- a/test/import-config/main.js
+++ b/test/import-config/main.js
@@ -1,0 +1,3 @@
+var one = require("one");
+
+window.moduleValue = one;

--- a/test/import-config/other.js
+++ b/test/import-config/other.js
@@ -1,0 +1,7 @@
+"format cjs";
+
+System.config({
+	map: {
+		"one": "two"
+	}
+});

--- a/test/import-config/prod.html
+++ b/test/import-config/prod.html
@@ -1,0 +1,4 @@
+<script src="../../bower_components/steal/steal.js"
+		data-main="main"
+		data-base-url="./"
+		data-env="production"></script>

--- a/test/import-config/two.js
+++ b/test/import-config/two.js
@@ -1,0 +1,1 @@
+module.exports = "it worked";

--- a/test/plugins/site.html
+++ b/test/plugins/site.html
@@ -1,4 +1,5 @@
 <div id="main"></div>
 <script src="../../bower_components/steal/steal.js"
         data-main="main"
+		data-log-level="3"
         data-config="./config.js"></script>

--- a/test/test.js
+++ b/test/test.js
@@ -15,6 +15,8 @@ var dependencyGraph = require("../lib/graph/make_graph"),
 	logging = require('../lib/logger'),
 	pluginifierBuilder = require('../lib/build/pluginifier_builder');
 
+System.logLevel = 3;
+
 // Helpers
 var find = function(browser, property, callback, done){
 	var start = new Date();
@@ -58,7 +60,8 @@ describe('dependency graph', function(){
 
 		dependencyGraph({
 			config: __dirname+"/stealconfig.js",
-			startId: "basics"
+			startId: "basics",
+			logLevel: 3
 		}).then(function(data){
 			var result = comparify(data.graph, {
 				"@config": {
@@ -99,7 +102,8 @@ describe('dependency graph', function(){
 		dependencyGraph({
 			config: __dirname + "/stealconfig.js",
 			startId: "basics",
-			extra: "stuff"
+			extra: "stuff",
+			logLevel: 3
 		}).then(function(data){
 			var steal = data.steal;
 			var extra = steal.config("extra");
@@ -113,7 +117,8 @@ describe('dependency graph', function(){
 		it("Map should work", function(done){
 			dependencyGraph({
 				config: __dirname + "/stealconfig.js",
-				startId: "basics"
+				startId: "basics",
+				logLevel: 3
 			}).then(function(data){
 				var graph = data.graph;
 
@@ -138,7 +143,8 @@ describe("bundle", function(){
 
 		bundle({
 			config: __dirname+"/bundle/stealconfig.js",
-			main: "bundle"
+			main: "bundle",
+			logLevel: 3
 		}).then(function(data){
 			var graphCompare = require('./bundle/bundle_graph');
 			comparify(data.graph, graphCompare, true);
@@ -1014,7 +1020,8 @@ describe("multi-main", function(){
 				main: mains
 			}, {
 				bundleSteal: true,
-				quiet: true
+				quiet: true,
+				minify: false
 			}).then(function(data){
 				
 				var checkNext = function(next){
@@ -1189,6 +1196,54 @@ describe("@loader used in configs", function() {
 		
 	});
 
+
+});
+
+describe("importing into config", function(){
+	it("works", function(done){
+		rmdir(__dirname + "/import-config/dist", function(error){
+			if(error) return done(error);
+
+			multiBuild({
+				config: __dirname + "/import-config/config.js",
+				main: "main"
+			}, {
+				quiet: true
+			}).then(function(){
+				open("test/import-config/prod.html", function(browser, close){
+
+					find(browser,"moduleValue", function(moduleValue){
+						assert.equal(moduleValue, "it worked", "Importing a config within a config works");
+						close();
+					}, close);
+
+				}, done);
+			}).catch(done);
+		});
+	});
+
+	it("works bundled with steal", function(done){
+		rmdir(__dirname + "/import-config/dist", function(error){
+			if(error) return done(error);
+
+			multiBuild({
+				config: __dirname + "/import-config/config.js",
+				main: "main"
+			}, {
+				quiet: true,
+				bundleSteal: true
+			}).then(function(){
+				open("test/import-config/bundled.html", function(browser, close){
+
+					find(browser,"moduleValue", function(moduleValue){
+						assert.equal(moduleValue, "it worked", "Importing a config within a config works");
+						close();
+					}, close);
+
+				}, done);
+			}).catch(done);
+		});
+	});
 
 });
 


### PR DESCRIPTION
This fixes issues surrounding loading the @config prior to the main in production. The issues were:
1. bundleSteal was not working with the old method.
2. System.defines that are dependencies of the @config would cause the app to never finish loading.

The new approach is to make the `@config` part of the main bundle in Steal and then to do:

``` js
System.import("@config").then(function(){
  System.import("main");
});
```

Since `@config` is part of the main bundle it will cause the main bundle to be loaded, and then the config will be loaded prior to the main.

To fix this we had to make it so that other mains are not included in the bundles config. This is important for the multi-app build because the `@config` is part of each main's bundle. Without removing these extra bundles it would cause more than one app to be loaded.

Fixes #133
