### PR TITLE
Set configMain when bundling steal

### DIFF
--- a/lib/bundle/add_steal.js
+++ b/lib/bundle/add_steal.js
@@ -5,6 +5,6 @@ var makeStealNode = require("../node/make_steal_node"),
 // makes it so this bundle loads steal
 module.exports = function(bundle, main, configuration){
 
-	bundle.nodes.unshift(makeNode("[production-config]","steal={env: 'production'};"), makeStealNode(configuration), makeNode("[add-define]","window.define = System.amdDefine;"));
+	bundle.nodes.unshift(makeNode("[production-config]","steal={env: 'production', configMain: '"+configuration.configMain+"'};"), makeStealNode(configuration), makeNode("[add-define]","window.define = System.amdDefine;"));
 	bundle.nodes.push( makeNode("[import-main-module]", "System.import('"+configuration.configMain+"').then(function() {\nSystem.import('"+main+"'); \n});") );
 };

--- a/test/npm/prod-bundled.html
+++ b/test/npm/prod-bundled.html
@@ -1,0 +1,4 @@
+<body>
+	<script src="dist/bundles/main.js"></script>
+</body>
+

--- a/test/test.js
+++ b/test/test.js
@@ -1909,6 +1909,32 @@ describe("npm package.json builds", function(){
 
 	});
 
+	it("works with bundleSteal", function(done){
+		this.timeout(50000);
+		setup(function(error){
+			if(error){ return done(error); }
+			
+			multiBuild({
+				config: path.join(__dirname, "npm", "package.json!npm")
+			}, {
+				quiet: true,
+				minify: false,
+				bundleSteal: true
+			}).then(function(){
+				// open the prod page and make sure
+				// and make sure the module loaded successfully
+				open("test/npm/prod-bundled.html", function(browser, close){
+					var h1s = browser.window.document.getElementsByTagName('h1');
+					assert.equal(h1s.length, 1, "Wrote H!.");
+					close();
+				}, done);
+
+			}).catch(done);
+			
+		});
+
+	});
+
 	it("only needs a config and works with bundles", function(done){
 		setup(function(error){
 			if(error){ return done(error); }


### PR DESCRIPTION
This changes `production-config` to include the `configMain`, so that when Steal is bundled it doesn't try to load stealconfig.js. Fixes #191