### PR TITLE
Remove global define from window after loading

### DIFF
--- a/lib/bundle/add_global_shim.js
+++ b/lib/bundle/add_global_shim.js
@@ -8,11 +8,15 @@ module.exports = function(bundle, options){
 	
 	var exports = options.exports; // ? exportsForDependencies(bundle.nodes, options.exports) : {};
 	var source = "("+shim.toString()+")("+JSON.stringify(exports)+",window)";
-	var node = makeNode("[global-shim]",source);
+	var start = makeNode("[global-shim-start]", source);
+	source = "("+shimEnd.toString()+")();";
+	var end = makeNode("[global-shim-end]", source);
 	if(options.minify){
-		minify([node]);
+		minify([start]);
+		minify([end]);
 	}
-	bundle.nodes.unshift(node);
+	bundle.nodes.unshift(start);
+	bundle.nodes.push(end);
 };
 
 // This only includes exports for loads in the bundle and their dependencies. 
@@ -47,7 +51,8 @@ var shim = function(exports, global){
 		}
 		return cur;
 	};
-	var modules = global.define && global.define.modules || {};
+	var modules = (global.define && global.define.modules) ||
+		(global._define && global._define.modules) || {};
 	var ourDefine = global.define = function(moduleName, deps, callback){
 		var module;
 		if(typeof deps === "function") {
@@ -80,6 +85,7 @@ var shim = function(exports, global){
 		// Favor CJS module.exports over the return value
 		modules[moduleName] = module && module.exports ? module.exports : result;
 	};
+	global.define.orig = origDefine;
 	global.define.modules = modules;
 	global.define.amd = true;
 	global.System = {
@@ -89,4 +95,9 @@ var shim = function(exports, global){
 			global.define = ourDefine;
 		}
 	};
+};
+
+var shimEnd = function(){
+	window._define = window.define;
+	window.define = window.define.orig;
 };

--- a/test/pluginifier_builder_helpers/global.html
+++ b/test/pluginifier_builder_helpers/global.html
@@ -9,7 +9,7 @@
 		<script src="./dist/global/tabs.js"></script>
 		<script>
 			$("#tabs").tabs();
-			define("foo",["tabs"], function(tabs){
+			_define("foo",["tabs"], function(tabs){
 				window.TABS = tabs["default"];
 			});
 		</script>

--- a/test/pluginify/index.html
+++ b/test/pluginify/index.html
@@ -1,2 +1,5 @@
 <script src="out.js"></script>
 <script src="umd.js"></script>
+<script>
+	window.RESULT.define = window.define;
+</script>

--- a/test/pluginify/index.html
+++ b/test/pluginify/index.html
@@ -1,1 +1,2 @@
 <script src="out.js"></script>
+<script src="umd.js"></script>

--- a/test/pluginify/umd.js
+++ b/test/pluginify/umd.js
@@ -1,0 +1,11 @@
+(function(root, factory){
+
+	if (typeof define === 'function' && define.amd) {
+		define([], factory);	
+	} else {
+		window.RESULT.UMD = factory();
+	}
+
+})(this, function(){
+	return "works";
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1051,6 +1051,7 @@ describe("transformImport", function(){
 						assert(result.module.es6module, "have dependeny");
 						assert(result.cjs(), "cjs");
 						assert.equal(result.global, "This is a global module", "Global module loaded");
+						assert.equal(result.UMD, "works", "Doesn't mess with UMD modules");
 						close();
 					}, close);
 
@@ -1209,7 +1210,6 @@ describe("transformImport", function(){
 				});
 			});
 		});
-
 	});
 
 	it("Works with modules that check for define.amd", function(done){

--- a/test/test.js
+++ b/test/test.js
@@ -1052,6 +1052,7 @@ describe("transformImport", function(){
 						assert(result.cjs(), "cjs");
 						assert.equal(result.global, "This is a global module", "Global module loaded");
 						assert.equal(result.UMD, "works", "Doesn't mess with UMD modules");
+						assert.equal(result.define, undefined, "Not keeping a global.define");
 						close();
 					}, close);
 


### PR DESCRIPTION
The global define interferes with UMD modules that expect to be loaded by a real amd loader. This fixes it by instead storing itself on `global._define` instead. Fixes #200