### PR TITLE
Remove global.System from global shim

### DIFF
--- a/lib/bundle/add_global_shim.js
+++ b/lib/bundle/add_global_shim.js
@@ -93,11 +93,13 @@ var shim = function(exports, global){
 			global.define = origDefine;
 			eval("(function() { " + __code + " \n }).call(global);");
 			global.define = ourDefine;
-		}
+		},
+		orig: global.System
 	};
 };
 
 var shimEnd = function(){
 	window._define = window.define;
 	window.define = window.define.orig;
+	window.System = window.System.orig;
 };

--- a/test/pluginify/index.html
+++ b/test/pluginify/index.html
@@ -2,4 +2,5 @@
 <script src="umd.js"></script>
 <script>
 	window.RESULT.define = window.define;
+	window.RESULT.System = window.System;
 </script>

--- a/test/test.js
+++ b/test/test.js
@@ -1053,6 +1053,7 @@ describe("transformImport", function(){
 						assert.equal(result.global, "This is a global module", "Global module loaded");
 						assert.equal(result.UMD, "works", "Doesn't mess with UMD modules");
 						assert.equal(result.define, undefined, "Not keeping a global.define");
+						assert.equal(result.System, undefined, "Not keeping a global.System");
 						close();
 					}, close);
 


### PR DESCRIPTION
In the global shim we create a global.System to execute globals, but unlike the define we do not remove it from the window after the script has executed. This change removes it. Fixes #206