### PR TITLE
Base helper dest denpms module names

### DIFF
--- a/lib/build/helpers/amd.js
+++ b/lib/build/helpers/amd.js
@@ -111,9 +111,9 @@ module.exports = (baseHelper.makeHelper(baseHelper.extend(cjsCopy, {
 			
 			// if it ends in /
 			var parts = depName.split("/"),
-				last = parts[parts.lenght - 1];
+				last = parts[parts.length - 1];
 				
-			if(parts.length > 2 && (!last || last === parts[parts.lenght - 2]) ) {
+			if(parts.length > 2 && (!last || last === parts[parts.length - 2]) ) {
 				parts.pop();
 				depName = parts.join("/");
 			}

--- a/lib/build/helpers/base.js
+++ b/lib/build/helpers/base.js
@@ -1,5 +1,6 @@
 var path = require("path");
 var supportedBuildTypes = ["js","css"];
+var npmUtils = require("steal/ext/npm-utils");
 
 var extend = function(d, s){
 	for(var prop in s){
@@ -93,6 +94,10 @@ var baseHelper = {
 				
 				if(aliases[moduleName]) {
 					return path.join(baseRoot, aliases[moduleName]);
+				}
+
+				if(npmUtils.moduleName.isNpm(moduleName)) {
+					moduleName = npmUtils.moduleName.parse(moduleName).modulePath;
 				}
 				
 				// move it to lib/cjs and rename it

--- a/test/pluginifier_builder_helpers/src/tabs.js
+++ b/test/pluginifier_builder_helpers/src/tabs.js
@@ -1,5 +1,6 @@
 import $ from "jquery";
 import "./tabs.less!";
+import "./utils/utils";
 
 $.fn.tabs = function(){
 	this.addClass("tabs").text("tabs!");

--- a/test/pluginifier_builder_helpers/src/utils/utils.js
+++ b/test/pluginifier_builder_helpers/src/utils/utils.js
@@ -1,0 +1,1 @@
+module.exports = function(){};

--- a/test/test.js
+++ b/test/test.js
@@ -2077,7 +2077,7 @@ describe("Source Maps", function(){
 
 		function verify() {
 			var globalJsMap = read("global/tabs.js.map");
-			assert.equal(globalJsMap.sources[0], "../../src/tabs.js", "Relative to source file");
+			assert.equal(globalJsMap.sources[1], "../../src/tabs.js", "Relative to source file");
 			assert.equal(globalJsMap.file, "tabs.js", "Refers to generated file");
 
 			var globalJs = read("global/tabs.js");


### PR DESCRIPTION
This changes the base helper to run a "denpm" function on moduleNames that are npm-like. This bug never surfaced until we encountered a package with a deep folder structure. Fixes #214