### PR TITLE
Only export sourcemaps if option enabled.

### DIFF
--- a/lib/build/export.js
+++ b/lib/build/export.js
@@ -104,7 +104,9 @@ module.exports = function(config, defaults, modules){
 							if(err) {
 								errors.push(err);
 							}
-							if(map) {
+							var sourceMaps = map && config.options &&
+								config.options.sourceMaps;
+							if(sourceMaps) {
 								fs.writeFile(filename+".map", map+"", function(err){
 									if(err) { errors.push(err); }
 									check();

--- a/lib/build/transform.js
+++ b/lib/build/transform.js
@@ -130,7 +130,9 @@ var transformImport = function(config, transformOptions){
 				winston.debug("+ %s", node.load.name);
 			});
 			concatSource(bundle,"activeSource", options.format === "global");
-			addSourceMapUrl(bundle);
+			if(options.sourceMaps) {
+				addSourceMapUrl(bundle);
+			}
 			
 			return bundle.source;
 		};


### PR DESCRIPTION
We are always creating source maps due to the use of source-map for concating, but we only want to export them if the `sourceMaps` option is set to `true`.