### PR TITLE
Watch mode

### DIFF
--- a/bin/steal
+++ b/bin/steal
@@ -15,7 +15,10 @@ var yargs = require("yargs")
 	.alias("o", "out")
 	.describe("source-maps", "Generate source maps")
 	.describe("source-maps-content", "Include the original source contents with the source maps")
+	.describe("minify", "Minify the output. Defaults to true except when used with --watch")
 	.describe("no-minify", "Do not minify the output")
+	.describe("w", "Watch for file changes and rebuild")
+	.alias("w", "watch")
 	.describe("verbose", "Verbose output")
 	.describe("quiet", "Quiet output")
 	.version(require("../package.json").version, "version")
@@ -74,9 +77,14 @@ if(command === "build"){
 
 function build() {
 
-	stealTools.build(system, options).then(function(){
-		winston.info('\nBuild completed successfully'.green);
-	});
+	var promise = stealTools.build(system, options);
+
+	// If this is watch mode this is actually a stream.
+	if(promise.then) {
+		promise.then(function(){
+			winston.info('\nBuild completed successfully'.green);
+		});
+	}
 
 }
 

--- a/doc/build.md
+++ b/doc/build.md
@@ -56,12 +56,9 @@ Specifies the behavior of the build.
 
   @option {Boolean} [sourceMapsContent=false] Include the original source contents in the generated source maps. Use this option if your production environment doesn't have access to the source files. Will result in a larger source maps size but will cause fewer requests.
 
-@return {Promise<{}>} A promise that resolves, if successful to an object with the following data:
+  @option {Boolean} [watch=false] Actives watch mode which will continuously build as you develop your application.
 
-  @option {buildGraph} graph A map of moduleNames to node.
-  @option {steal} steal The steal function used to load the main module.
-  @option {Loader} loader The loader used to load the main module.
-  @option {Array} bundles The builds written out.
+@return {(Promise<steal-tools.BuildResult>|Stream<steal-tools.BuildResult>)} Either a Promise that resolves when the build is complete or a Stream that will send `data` events every time a rebuild is complete. By default a Promise is returned, unless the `watch` option is enabled.
 
 @body
 

--- a/doc/guides/watch_mode.md
+++ b/doc/guides/watch_mode.md
@@ -1,0 +1,123 @@
+@page steal-tools.guides.watch_mode Continuous Builds
+@parent StealJS.guides 2
+
+In 0.9.0 StealTools added a new **watch** mode to its multi-build. This enables you to continuously rebuild your application as you work. This is useful if you prefer a workflow where you are debugging your application as it will appear in production. In this guide we'll go through the process of setting up a CanJS project using the watch mode.
+
+## Setup
+
+The guide assumes some basic knowledge of [Node.js](http://nodejs.org). If you haven't used Node before, please go learn more about how it works on their website.
+
+To get started we want to create a new Node.js application and install the packages we'll need.
+
+```shell
+> npm init
+> npm install steal-tools -g
+> npm install steal --save
+> npm install can --save
+```
+
+Running `npm init` will ask you a series of questions. The answers aren't important and can be changed later by editing the produced `package.json` file.
+
+Before we can start using the **watch** mode we'll need to create our main file. This is the entry point to your application and was specified in the `npm init` process. Assuming we called it `main.js` let's open up that file and get an initial build started.
+
+### main.js
+
+```js
+var can = require("can");
+```
+
+## Enable watch mode
+
+Now that we have our skeleton ready we can turn on watch mode.
+
+```shell
+steal-tools --watch
+```
+
+This will take a second or so and then you'll get an output:
+
+```shell
+[9:09:19 AM]
+Watch mode ready.
+```
+
+This tells us that the initial build has been complete and watch mode is ready to rebuild our application as we develop.
+
+## Develop your application
+
+From here you can begin developing your application any way you like. Let's create a simple `hello-world` component to show how the output updates every time you modify your application. Back in `main.js` add this:
+
+```js
+var can = require("can");
+require("can/view/stache/");
+require("./components/hello/");
+```
+
+You'll get a message indicating that StealTools cannot find the hello component:
+
+```shell
+File not found: /path/to/can-proj/components/hello/hello.js
+```
+
+So let's go create it.
+
+### components/hello/hello.js
+
+```js
+require("can/view/stache/");
+var template = require("./hello.stache");
+var can = require("can");
+
+can.Component.extend({
+	tag: "hello-world",
+	viewModel: {
+		name: "world"
+	},
+	template: template
+});
+```
+
+### components/hello/hello.stache
+
+```html
+<div>
+Hellos \{{name}}!
+</div>
+```
+
+### main.js
+
+Now back in your main add the component to your page:
+
+```js
+var can = require("can");
+require("can/view/stache/");
+require("./components/hello/");
+
+var template = can.stache("<hello-world></hello-world>");
+can.$("body").append(template());
+```
+
+Each time you save you will get new output; it will either be a timestamp by itself (when creating new modules) or a timestamp with the module name (when modifying an existing module). The output will be like:
+
+```shell
+[9:20:16 AM]
+[9:20:22 AM]: components/hello/hello
+[9:21:49 AM]: main
+```
+
+## Debug your application
+
+Now that we've got a basic application written let's check out the debugging experience. First let's create a simple page:
+
+### index.html
+
+```html
+<script src="node_modules/steal/steal.js"
+	env="production"
+	main="main"></script>
+```
+
+Open the page in a browser and open your debug tools. With the watch mode source maps are enabled by default. You can see and debug your original code from your browser's debugging tools.
+
+That's it! As you develop and save your code StealTools will continuously rebuild your application.

--- a/doc/types/build-result.md
+++ b/doc/types/build-result.md
@@ -1,0 +1,13 @@
+@typedef {{}} steal-tools.BuildResult BuildResult
+@parent steal-tools.types
+
+The result if a [steal-tools.build multi-build].
+
+@option {buildGraph} graph A map of moduleNames to node.
+
+@option {steal} steal The steal function used to load the main module.
+
+@option {Loader} loader The loader used to load the main module.
+
+@option {Array} bundles The builds written out.
+

--- a/lib/build/continuous.js
+++ b/lib/build/continuous.js
@@ -6,29 +6,27 @@ var watch = require("../stream/watch");
 var defaults = require("lodash").defaults;
 
 module.exports = function(config, options){
+	var moment = require("moment");
+
 	defaults(options, {
 		sourceMaps: true,
 		minify: false,
 		quiet: true
 	});
 
-	var start = new Date(), moduleName;
+	var moduleName;
 
 	// A function that is called whenever a module is found by the watch stream.
 	// Called with the name of the module and used to rebuild.
 	function rebuild(node){
-		start = new Date();
 		moduleName = node ? node.load.name : "";
 		rebuildStream.write(moduleName);
 	}
 
 	function log(){
-		var ms = new Date() - start;
-		var rebuiltPart = "";
-		if(moduleName) {
-			rebuiltPart = "[" + moduleName + "]";
-		}
-		console.log(rebuiltPart.red + (moduleName ? ":" : ""), ms.toString().green, "ms");
+		var rebuiltPart = moduleName ? moduleName : "";
+		var time = "[" + moment().format("LTS") + "]";
+		console.log(time.red + (moduleName ? ":" : ""), rebuiltPart.green);
 	}
 
 	// Create an initial dependency graph for this config.
@@ -46,6 +44,9 @@ module.exports = function(config, options){
 	// Watch the build stream and call rebuild whenever it changes.
 	watch(buildStream, rebuildStream, rebuild);
 	buildStream.on("data", log);
+	buildStream.once("data", function(){
+		console.log("Watch mode ready.");
+	});
 	
 	// Writing into the graph stream is what triggers the process to start.
 	graphStream.write(config.main);

--- a/lib/build/continuous.js
+++ b/lib/build/continuous.js
@@ -1,0 +1,53 @@
+var createBundleGraphStream = require("../graph/make_graph_with_bundles").createBundleGraphStream;
+var regraph = require("../graph/regraph");
+var multiBuild = require("../stream/build");
+var createWriteStream = require("../bundle/write_bundles").createWriteStream;
+var watch = require("../stream/watch");
+var defaults = require("lodash").defaults;
+
+module.exports = function(config, options){
+	defaults(options, {
+		sourceMaps: true,
+		minify: false,
+		quiet: true
+	});
+
+	var start = new Date(), moduleName;
+
+	// A function that is called whenever a module is found by the watch stream.
+	// Called with the name of the module and used to rebuild.
+	function rebuild(node){
+		start = new Date();
+		moduleName = node ? node.load.name : "";
+		rebuildStream.write(moduleName);
+	}
+
+	function log(){
+		var ms = new Date() - start;
+		var rebuiltPart = "";
+		if(moduleName) {
+			rebuiltPart = "[" + moduleName + "]";
+		}
+		console.log(rebuiltPart.red + (moduleName ? ":" : ""), ms.toString().green, "ms");
+	}
+
+	// Create an initial dependency graph for this config.
+	var graphStream = createBundleGraphStream(config);
+	// Create a stream that is used to regenerate a new graph on file changes.
+	var rebuildStream = regraph(config);
+
+	// Create a build stream that does everything; creates a graph, bundles,
+	// and writes the bundles to the filesystem.
+	var buildStream = graphStream
+		.pipe(rebuildStream)
+		.pipe(multiBuild(config, options))
+		.pipe(createWriteStream());
+
+	// Watch the build stream and call rebuild whenever it changes.
+	watch(buildStream, rebuildStream, rebuild);
+	buildStream.on("data", log);
+	
+	// Writing into the graph stream is what triggers the process to start.
+	graphStream.write(config.main);
+	return buildStream;
+};

--- a/lib/build/multi.js
+++ b/lib/build/multi.js
@@ -1,232 +1,37 @@
-/*
-
-# lib/build/multi.js
-
-The bundled build works by loading the _main_ module and all of its
-dependencies and then all of the `System.bundle` modules 
-and their dependencies. It makes a dependency graph that looks like:
-
-```js
-{
-  moduleName: Node({
-    load: Load({
-      name: moduleName,
-      source: SOURCE
-    }),
-    dependencies: [moduleName],
-    bundles: [bundleName],
-  })
-}
-```
-
-Here's an example:
-
-```js
-{
-  "jquery": {
-    load: {
-      name: "jquery",
-      source: "jQuery = function(){ ... }"
-    },
-    dependencies: [],
-    bundles: ["profile","settings","login", ...]
-  },
-  "can/util": {
-    load: {
-      name: "can/util",
-      source: "define(['jquery'], function($){ ... })" 
-    },
-    dependencies: ["jquery"],
-    bundles: ["profile","login"]
-  }
-}
-```
-
-A `Load` is a ES6 load record.
-
-A `Node` is an object that contains the load and other 
-useful information. The build tools only write to `Node` to keep `Load` from being changed.
-
-It manipulates this graph and eventually creates "bundle" graphs.  Bundle graphs look like:
-
-     {
-       size: 231231,
-       nodes: [node1, node2, ...],
-       bundles: [bundleName1, bundleName2]	
-     }
-     
-The nodes in those bundles are written to the filesystem.
-
-*/
-var winston = require('winston');
-
-var makeBundleGraph = require("../graph/make_graph_with_bundles"),
-	order = require("../graph/order"),
-	transpile = require("../graph/transpile"),
-	minifyGraph = require("../graph/minify"),
-	pluck = require("../graph/pluck"),
-	makeBundle = require("../bundle/make_bundle"),
-	nameBundle = require("../bundle/name"),
-	flattenBundle = require("../bundle/flatten"),
-	writeBundles = require("../bundle/write_bundles"),
-	makeBundlesConfig = require("../bundle/make_bundles_config"),
-	splitByBuildType = require("../bundle/split_by_build_type"),
-	addStealToBundle = require("../bundle/add_steal"),
-	_ = require("lodash"),
-	logging = require("../logger"),
-	hasES6 = require("../graph/has_es6"),
-	clean = require("../graph/clean"),
-	addTraceurRuntime = require("../bundle/add_traceur_runtime"),
-	makeConfiguration = require("../configuration/make"),
-	splitGraphByModuleNames = require("../graph/split"),
-	getBundleForOnly = require("../bundle/get_for_only"),
-	findBundles = require("../loader/find_bundle");
+var createBundleGraphStream = require("../graph/make_graph_with_bundles").createBundleGraphStream;
+var multiBuild = require("../stream/build");
+var createWriteStream = require("../bundle/write_bundles").createWriteStream;
+var continuousBuild = require("./continuous");
 
 module.exports = function(config, options){
-	options = _.assign({ // Defaults
-		minify: true,
-		bundleSteal: false,
-		uglifyOptions: {},
-		cleanCSSOptions: {},
-		removeDevelopmentCode: true,
-		namedDefines: true
-	}, options);
+	// Watch mode, return a continously building stream.
+	if(options.watch) {
+		
+		return continuousBuild(config, options);
 
-	if(options.sourceMaps) {
-		_.assign(config, {
-			lessOptions: _.assign({}, options.lessOptions, {
-				sourceMap: {}
-			})
+	} else {
+		// Get a stream containing the bundle graph
+		var graphStream = createBundleGraphStream(config);
+		// Pipe the bundle graph into the multiBuild
+		var buildStream = graphStream.pipe(multiBuild(config, options));
+
+
+		// Return a Promise that will resolve after bundles have been written;
+		return new Promise(function(resolve, reject){
+			// Pipe the multi build result into a write stream.
+			var writeStream = buildStream.pipe(createWriteStream());
+
+			writeStream.on("data", function(data){
+				this.end();
+				resolve(data);
+			});
+
+			[ graphStream, buildStream, writeStream ].forEach(function(stream){
+				stream.on("error", reject);
+			});
+
+			graphStream.write(config.main);
 		});
 	}
 
-	// Setup logging
-	logging.setup(options, config);
-
-	// Minification is optional
-	var minify = options.minify = options.minify !== false;
-
-	// Get the merged dependency graphs for each System.bundle.
-	return makeBundleGraph(config).then(function(data){
-		var dependencyGraph = data.graph,
-			// the apps we are building
-			mains = Array.isArray(config.main) ? config.main.slice(0) : [data.loader.main],
-			configuration = makeConfiguration(data.loader, data.buildLoader, options);
-
-		// Remove @config so it is not transpiled.  It is a global,
-		// but we will want it to run ASAP.
-		var stealconfig = pluck(dependencyGraph,data.loader.configMain ||"@config");
-
-		// Transpile the source to AMD
-		options.sourceMapPath = configuration.bundlesPath;
-		transpile(stealconfig, "amd", options, data);
-
-		// Remove steal dev from production builds.
-		pluck(dependencyGraph,"@dev");
-		
-		// Adds an `order` property to each `Node` so we know which modules.  
-		// The lower the number the lower on the dependency tree it is.
-		// For example, jQuery might have `order: 0`.
-		mains.forEach(function(moduleName){
-			order(dependencyGraph, moduleName);
-		});
-		
-		findBundles(data.loader).forEach(function(moduleName){
-			order(dependencyGraph, moduleName);
-		});
-
-		// Clean development code if the option was passed
-		if(options.removeDevelopmentCode) {
-			clean(dependencyGraph, options);
-		}
-
-		// Transpile each module to amd. Eventually, production builds
-		// should be able to work without steal.js.
-		winston.info('Transpiling...');
-		transpile(dependencyGraph, "amd", options, data);
-		
-		// Minify every file in the graph
-		if(minify) {
-			winston.info('Minifying...');
-			minifyGraph(dependencyGraph, options);
-			minifyGraph(stealconfig, options);
-		}
-
-		// Split the graph into two smaller graphs. One will contain the
-		// "mains" and their dependencies that need to be loaded right away.  
-		// The other will will be the bundles that are progressively loaded.
-		var splitGraphs = splitGraphByModuleNames(dependencyGraph, mains),
-			mainsGraph = splitGraphs["with"],
-			bundledGraph = splitGraphs.without;
-
-		winston.info('Calculating main bundle(s)...');
-		// Put everything into unique bundle graphs that have no waste. 
-		var mainBundles = makeBundle(mainsGraph);
-		// Combine bundles to reduce the number of total bundles that will need to be loaded
-		winston.info('Flattening main bundle(s)...');
-		flattenBundle(mainBundles,config.mainDepth || config.bundleDepth || 3);
-		// Break up bundles by buildType
-		var splitMainBundles = splitByBuildType(mainBundles);
-
-		var splitBundles = [];
-		if(!_.isEmpty(bundledGraph)) {
-			winston.info('Calculating progressively loaded bundle(s)...');
-			// Put everything into unique bundle graphs that have no waste. 
-			var bundles = makeBundle(bundledGraph);
-			// Combine bundles to reduce the number of total bundles that will need to be loaded
-			winston.info('Flattening progressively loaded bundle(s)...');
-			flattenBundle(bundles,config.bundleDepth || 3);
-			// Break up bundles by buildType
-			splitBundles = splitByBuildType(bundles);
-		}
-
-		
-		
-		// Every mainBundle needs to have @config and bundle configuration to know
-		// where everything is. Lets get those main bundles here while there is less to go through.
-
-		var mainJSBundles = mains.map(function(main){
-			return getBundleForOnly(splitMainBundles,main,"js");
-		});
-		
-		// Combine all bundles
-		var allBundles = splitMainBundles.concat(splitBundles);
-		// Name each bundle so we know what to call the bundle.
-		allBundles.forEach(nameBundle);
-		// Make sure the main bundle doesn't have an npm-normalized name
-		mainJSBundles.forEach(nameBundle.denpmed);
-
-		// Create a lookup object of the main bundle names so that they are
-		// excluded from the Bundles config
-		var mainJSBundleNames = {};
-		mainJSBundles.forEach(function(mainJSBundle){
-			mainJSBundleNames[mainJSBundle.name] = true;
-		});
-		
-		// Add @config and the bundleConfigNode to each main
-		mainJSBundles.forEach(function(mainJSBundle){
-			[].unshift.apply(mainJSBundle.nodes, stealconfig );
-			// Make config JS code so System knows where to look for bundles.
-			var configNode = makeBundlesConfig(allBundles, configuration, mainJSBundle, {
-				excludedBundles: mainJSBundleNames
-			});
-			mainJSBundle.nodes.unshift(configNode);
-			
-			if(options.bundleSteal) {
-				addStealToBundle(mainJSBundle, mainJSBundle.bundles[0], configuration);
-			}
-			// Traceur code requires a runtime.
-			var hasES6modules = hasES6(dependencyGraph);
-			if( hasES6modules ) {
-				addTraceurRuntime(mainJSBundle);
-			}
-			
-		});
-		
-		return writeBundles(allBundles, configuration );
-		
-	}).catch(function(e){
-		winston.error(e.message, e.stack);
-		throw e;
-	});
 };

--- a/lib/build/transform.js
+++ b/lib/build/transform.js
@@ -49,7 +49,8 @@ var transformImport = function(config, transformOptions){
 				removeDevelopmentCode: true,
 				format: "global",
 				includeTraceurRuntime: true,
-				ignoreAllDependencies: false
+				ignoreAllDependencies: false,
+				removeSourceNodes: true
 			},transformOptions, options);
 			var configuration = makeConfiguration(data.loader, data.buildLoader, options);
 

--- a/lib/bundle/concat_source.js
+++ b/lib/bundle/concat_source.js
@@ -36,7 +36,9 @@ module.exports = function(bundle, sourceProp, excludePlugins){
 	bundle.source = result;
 
 	function prependName(node, file) {
-		node.prepend("/*"+file.node.load.name+"*/\n");
+		if(node.prependModuleName !== false) {
+			node.prepend("/*"+file.node.load.name+"*/\n");
+		}
 	}
 };
 

--- a/lib/bundle/hash.js
+++ b/lib/bundle/hash.js
@@ -1,0 +1,18 @@
+var crypto = require("crypto");
+var sourceNode = require("../node/source").node;
+
+module.exports = function(bundle){
+	var md5sum = crypto.createHash("md5");
+	bundle.nodes.forEach(function(node){
+		var source = sourceNode(node);
+		var code = source.code || "";
+		md5sum.update(code);
+	});
+
+	var hash = md5sum.digest("hex");
+
+	//console.log("Hash is:", hash);
+
+	return hash;
+
+};

--- a/lib/bundle/mark_as_dirty.js
+++ b/lib/bundle/mark_as_dirty.js
@@ -1,0 +1,21 @@
+var hashBundle = require("./hash");
+var reduce = require("lodash").reduce;
+
+// Goes through each bundle and marks it as dirty if it's md5 hash representation
+// has changed. This is used for rebuilding to prevent writing out bundles
+// that have not changed.
+module.exports = function(bundles, data){
+	var bundlesKeyed = data.bundles || {};
+
+	data.bundles = reduce(bundles, function(result, bundle){
+		var hash;
+		if(bundlesKeyed[bundle.name]) {
+			hash = bundlesKeyed[bundle.name].hash;
+		}
+		bundle.hash = hashBundle(bundle);
+		bundle.isDirty = hash !== bundle.hash;
+
+		result[bundle.name] = bundle;
+		return result;
+	}, {});
+};

--- a/lib/bundle/write_bundles.js
+++ b/lib/bundle/write_bundles.js
@@ -4,14 +4,15 @@
 
 var winston = require('winston');
 var bundleFilename = require("./filename"),
-  concatSource = require("../bundle/concat_source"),
-  normalizeSource = require('./normalize_source'),
-  fs = require("fs"),
-  mkdirp = require("fs-extra").mkdirp,
-  dirname = require("path").dirname,
-  addSourceMapUrl = require("../bundle/add_source_map_url");
+	concatSource = require("../bundle/concat_source"),
+	normalizeSource = require('./normalize_source'),
+	fs = require("fs"),
+	mkdirp = require("fs-extra").mkdirp,
+	dirname = require("path").dirname,
+	addSourceMapUrl = require("../bundle/add_source_map_url"),
+	through = require("through2");
 
-module.exports = function(bundles, configuration) {
+var writeBundles = module.exports = function(bundles, configuration) {
   var bundlesDir = configuration.bundlesPath + "/";
   // Create the bundle directory
   var bundleDirDef = configuration.mkBundlesPathDir();
@@ -24,15 +25,23 @@ module.exports = function(bundles, configuration) {
     builtBundleDeferreds.push(new Promise(function(resolve, reject) {
       var bundlePath = bundlesDir + "" + bundleFilename(bundle);
 
+	  // If the bundle is explicity marked as clean, just resolve.
+	  if(bundle.isDirty === false) {
+		return resolve(bundle);
+	  }
+
       // Adjusts URLs
       normalizeSource(bundle, bundlePath);
 
       // Combines the source
       concatSource(bundle);
 
-	  addSourceMapUrl(bundle);
-	  var code = bundle.source.code;
-	  var map = bundle.source.map;
+	  var code = bundle.source.code, map;
+	  if(configuration.options.sourceMaps) {
+		  addSourceMapUrl(bundle);
+		  code = bundle.source.code;
+		  map = bundle.source.map;
+	  }
 	  
       // Log the bundles
       winston.info("BUNDLE: %s", bundleFilename(bundle));
@@ -55,6 +64,7 @@ module.exports = function(bundles, configuration) {
               } else {
                 if(!map) {
                   resolve(bundle);
+				  return;
                 }
                 // Write out the source map
                 fs.writeFile(bundlePath+".map", map, function(err) {
@@ -77,4 +87,15 @@ module.exports = function(bundles, configuration) {
 
 };
 
-		
+writeBundles.createWriteStream = function(){
+	function write(buildResult, enc, done) {
+		var configuration = buildResult.configuration;
+		var bundles = buildResult.bundles;
+
+		writeBundles(bundles, configuration).then(function(){
+			done(null, bundles);
+		}, done);
+	}
+
+	return through.obj(write);
+};

--- a/lib/graph/make_graph_with_bundles.js
+++ b/lib/graph/make_graph_with_bundles.js
@@ -1,6 +1,7 @@
 var dependencyGraph = require("./make_graph");
 var _ = require("lodash");
 var normalizeBundle = require("../loader/normalize_bundle");
+var through = require("through2");
 
 function addBundleOnEveryModule (graph, bundle){
 	for(var name in graph) {
@@ -27,7 +28,7 @@ function mergeIntoMasterAndAddBundle (masterGraph, newGraph, bundle) {
 	}
 }
 
-module.exports = function(config){
+var makeBundleGraph = module.exports = function(config){
 	
 	// the names of everything we are going to load
 	var bundleNames = [];
@@ -80,5 +81,15 @@ module.exports = function(config){
 		
 		return getNextGraphAndMerge();
 		
+	});
+};
+
+// A Stream version of makeBundleGraph
+makeBundleGraph.createBundleGraphStream = function(){
+	var args = arguments;
+	return through.obj(function(moduleName, enc, done){
+		return makeBundleGraph.apply(null, args).then(function(data){
+			done(null, data);
+		}, done);
 	});
 };

--- a/lib/graph/regraph.js
+++ b/lib/graph/regraph.js
@@ -25,7 +25,7 @@ module.exports = function(config){
 					graph[name].transforms = oldGraph[name].transforms;
 				}
 			}
-			cachedData = data;
+			cachedData = cloneData(data);
 			done(null, data);
 		}, done);
 	}
@@ -36,10 +36,16 @@ module.exports = function(config){
 		delete node.sourceNode;
 	}
 
+	function cloneData(data) {
+		var newData = clone(data);
+		newData.graph = clone(newData.graph);
+		return newData;
+	}
+
 	function cached(data, enc, next){
 		// This will only happen the first time, just to cache.
 		if(typeof data === "object") {
-			cachedData = data;
+			cachedData = cloneData(data);
 			next(null, data);
 		} else {
 			var moduleName = data;
@@ -53,6 +59,7 @@ module.exports = function(config){
 					if(same(node.deps, result.deps)) {
 						clean(node, result.source);
 						removeActiveSourceKeys(cachedData.graph);
+						cachedData = cloneData(cachedData);
 						return next(null, cachedData);
 					}
 					regenerate(moduleName, next);

--- a/lib/graph/regraph.js
+++ b/lib/graph/regraph.js
@@ -1,0 +1,71 @@
+var makeBundleGraph = require("./make_graph_with_bundles");
+var through = require("through2");
+var clone = require("lodash").clone;
+var getDependencies = require("../node_trace");
+var xor = require("lodash").xor;
+var removeActiveSourceKeys = require("./remove_active_source_keys");
+
+/**
+ * @module regraph
+ * @description Consumes a Dependency Graph and can regenerate another when
+ * modules change.
+ */
+module.exports = function(config){
+	var cachedData;
+
+	// Regenerate a new bundle graph and copy over the transforms so they can
+	// be reused.
+	function regenerate(moduleName, done){
+		var cfg = clone(config, true);
+		makeBundleGraph(cfg).then(function(data){
+			var graph = data.graph;
+			var oldGraph = cachedData.graph;
+			for(var name in graph){
+				if(name !== moduleName && oldGraph[name]) {
+					graph[name].transforms = oldGraph[name].transforms;
+				}
+			}
+			cachedData = data;
+			done(null, data);
+		}, done);
+	}
+
+	function clean(node, newSource) {
+		node.load.source = newSource;
+		delete node.transforms;
+		delete node.sourceNode;
+	}
+
+	function cached(data, enc, next){
+		// This will only happen the first time, just to cache.
+		if(typeof data === "object") {
+			cachedData = data;
+			next(null, data);
+		} else {
+			var moduleName = data;
+
+			// Get the old node and check to see if it has any new dependencies,
+			// if so just regenerate the entire graph.
+			var node = cachedData.graph[moduleName];
+			if(node) {
+				getDependencies(node.load).then(function(result){
+					// If the deps are the same we can return the existing graph.
+					if(same(node.deps, result.deps)) {
+						clean(node, result.source);
+						removeActiveSourceKeys(cachedData.graph);
+						return next(null, cachedData);
+					}
+					regenerate(moduleName, next);
+				});
+			} else {
+				regenerate(null, next);
+			}
+		}
+	}
+
+	return through.obj(cached);
+};
+
+function same(a, b){
+	return !xor(a, b).length;
+}

--- a/lib/graph/remove_active_source_keys.js
+++ b/lib/graph/remove_active_source_keys.js
@@ -1,9 +1,11 @@
-
-var clean = function(node){
+var clean = function(node, options){
 	delete node.activeSourceKeys;
 	node.activeSource = {
 		code: node.load.source
 	};
+	if(options.removeSourceNodes) {
+		delete node.sourceNode;
+	}
 };
 
 module.exports = function(graph, options) {

--- a/lib/node/transform_active_source.js
+++ b/lib/node/transform_active_source.js
@@ -8,7 +8,7 @@ module.exports = function(node, key, getSource){
 	if(!node.transforms){
 		node.transforms = {};
 	}
-	
+
 	node.activeSourceKeys.push(key);
 	var keys = node.activeSourceKeys.join(",");
 	

--- a/lib/node_trace.js
+++ b/lib/node_trace.js
@@ -1,0 +1,21 @@
+var steal = require("steal");
+var fs = require("fs");
+var asap = require("pdenodeify");
+var readFile = asap(fs.readFile);
+var clone = require("lodash").clone;
+
+module.exports = function(load){
+	load = clone(load);
+	load.metadata.deps = [];
+
+	var localSteal =  steal.clone(steal.addSteal(steal.System.clone()));
+	var System = localSteal.System;
+
+	var address = load.address.replace("file:", "");
+	return readFile(address, "utf8").then(function(source){
+		load.source = source;
+		return System.instantiate(load).then(function(result){
+			return { source: source, deps: result.deps };
+		});
+	});
+};

--- a/lib/source-map-concat.js
+++ b/lib/source-map-concat.js
@@ -1,48 +1,52 @@
 // Copyright 2014, 2015 Simon Lydell
 // X11 (“MIT”) Licensed. (See LICENSE.)
 
-var path              = require("path");
-var urix              = require("urix");
-var sourceMap         = require("source-map");
-var SourceNode        = sourceMap.SourceNode;
+var path							= require("path");
+var urix							= require("urix");
+var sourceMap					= require("source-map");
+var SourceNode				= sourceMap.SourceNode;
 var SourceMapConsumer = sourceMap.SourceMapConsumer;
 
 function concat(files, options) {
-  options = options || {};
+	options = options || {};
 
-  var concatenated = new SourceNode();
+	var concatenated = new SourceNode();
 
-  files.forEach(function(file, index) {
-    if (options.delimiter && index !== 0) {
-      concatenated.add(options.delimiter);
-    }
+	files.forEach(function(file, index) {
+		if (options.delimiter && index !== 0) {
+			concatenated.add(options.delimiter);
+		}
 
-    var node;
-    var map = file.map;
-    if (map) {
-      if (typeof map.toJSON === "function") {
-        map = map.toJSON();
-      }
-      node = SourceNode.fromStringWithSourceMap(
-        file.code,
-        new SourceMapConsumer(map),
-        urix(path.relative(
-          path.dirname( options.mapPath || "." ),
-          path.dirname( file.sourcesRelativeTo || "." )
-        ))
-      );
-    } else {
-      node = new SourceNode(null, null, null, file.code);
-    }
+		var node;
+		var map = file.map;
+		if (map) {
+			if(file.node.sourceNode) {
+				node = file.node.sourceNode;
+			} else {
+				if (typeof map.toJSON === "function") {
+					map = map.toJSON();
+				}
+				node = file.node.sourceNode = SourceNode.fromStringWithSourceMap(
+					file.code,
+					new SourceMapConsumer(map),
+					urix(path.relative(
+						path.dirname( options.mapPath || "." ),
+						path.dirname( file.sourcesRelativeTo || "." )
+					))
+				);
+			}
+		} else {
+			node = new SourceNode(null, null, null, file.code);
+		}
 
-    if (options.process) {
-      options.process(node, file, index);
-    }
+		if (options.process) {
+			options.process(node, file, index);
+		}
 
-    concatenated.add(node);
-  });
+		concatenated.add(node);
+	});
 
-  return concatenated;
+	return concatenated;
 }
 
 module.exports = concat;

--- a/lib/source-map-concat.js
+++ b/lib/source-map-concat.js
@@ -22,6 +22,7 @@ function concat(files, options) {
 		if (map) {
 			if(file.node.sourceNode) {
 				node = file.node.sourceNode;
+				node.prependModuleName = false;
 			} else {
 				if (typeof map.toJSON === "function") {
 					map = map.toJSON();

--- a/lib/stream/build.js
+++ b/lib/stream/build.js
@@ -1,0 +1,240 @@
+/*
+
+# lib/build/multi.js
+
+The bundled build works by loading the _main_ module and all of its
+dependencies and then all of the `System.bundle` modules 
+and their dependencies. It makes a dependency graph that looks like:
+
+```js
+{
+  moduleName: Node({
+    load: Load({
+      name: moduleName,
+      source: SOURCE
+    }),
+    dependencies: [moduleName],
+    bundles: [bundleName],
+  })
+}
+```
+
+Here's an example:
+
+```js
+{
+  "jquery": {
+    load: {
+      name: "jquery",
+      source: "jQuery = function(){ ... }"
+    },
+    dependencies: [],
+    bundles: ["profile","settings","login", ...]
+  },
+  "can/util": {
+    load: {
+      name: "can/util",
+      source: "define(['jquery'], function($){ ... })" 
+    },
+    dependencies: ["jquery"],
+    bundles: ["profile","login"]
+  }
+}
+```
+
+A `Load` is a ES6 load record.
+
+A `Node` is an object that contains the load and other 
+useful information. The build tools only write to `Node` to keep `Load` from being changed.
+
+It manipulates this graph and eventually creates "bundle" graphs.  Bundle graphs look like:
+
+     {
+       size: 231231,
+       nodes: [node1, node2, ...],
+       bundles: [bundleName1, bundleName2]	
+     }
+     
+The nodes in those bundles are written to the filesystem.
+
+*/
+var winston = require('winston'),
+	order = require("../graph/order"),
+	transpile = require("../graph/transpile"),
+	minifyGraph = require("../graph/minify"),
+	pluck = require("../graph/pluck"),
+	makeBundle = require("../bundle/make_bundle"),
+	nameBundle = require("../bundle/name"),
+	flattenBundle = require("../bundle/flatten"),
+	makeBundlesConfig = require("../bundle/make_bundles_config"),
+	splitByBuildType = require("../bundle/split_by_build_type"),
+	addStealToBundle = require("../bundle/add_steal"),
+	_ = require("lodash"),
+	logging = require("../logger"),
+	hasES6 = require("../graph/has_es6"),
+	clean = require("../graph/clean"),
+	addTraceurRuntime = require("../bundle/add_traceur_runtime"),
+	makeConfiguration = require("../configuration/make"),
+	splitGraphByModuleNames = require("../graph/split"),
+	getBundleForOnly = require("../bundle/get_for_only"),
+	findBundles = require("../loader/find_bundle"),
+	through = require("through2"),
+	markBundlesDirty = require("../bundle/mark_as_dirty");
+
+
+module.exports = function(config, options){
+	options = _.assign({ // Defaults
+		minify: true,
+		bundleSteal: false,
+		uglifyOptions: {},
+		cleanCSSOptions: {},
+		removeDevelopmentCode: true,
+		namedDefines: true
+	}, options);
+
+
+	if(options.sourceMaps) {
+		_.assign(config, {
+			lessOptions: _.assign({}, options.lessOptions, {
+				sourceMap: {}
+			})
+		});
+	}
+
+	// Setup logging
+	logging.setup(options, config);
+
+	// Minification is optional
+	var minify = options.minify = options.minify !== false;
+
+	return through.obj(function(data, enc, done){
+		var buildResult = multiBuild(data);
+		done(null, buildResult);
+	});
+
+	function multiBuild(data){
+		var dependencyGraph = data.graph,
+			// the apps we are building
+			mains = Array.isArray(config.main) ? config.main.slice(0) : [data.loader.main],
+			configuration = makeConfiguration(data.loader, data.buildLoader, options);
+
+		// Remove @config so it is not transpiled.  It is a global,
+		// but we will want it to run ASAP.
+		var stealconfig = pluck(dependencyGraph,data.loader.configMain ||"@config");
+
+		// Transpile the source to AMD
+		options.sourceMapPath = configuration.bundlesPath;
+		transpile(stealconfig, "amd", options, data);
+
+		// Remove steal dev from production builds.
+		pluck(dependencyGraph,"@dev");
+		
+		// Adds an `order` property to each `Node` so we know which modules.  
+		// The lower the number the lower on the dependency tree it is.
+		// For example, jQuery might have `order: 0`.
+		mains.forEach(function(moduleName){
+			order(dependencyGraph, moduleName);
+		});
+		
+		findBundles(data.loader).forEach(function(moduleName){
+			order(dependencyGraph, moduleName);
+		});
+
+		// Clean development code if the option was passed
+		if(options.removeDevelopmentCode) {
+			clean(dependencyGraph, options);
+		}
+
+		// Transpile each module to amd. Eventually, production builds
+		// should be able to work without steal.js.
+		winston.info('Transpiling...');
+		transpile(dependencyGraph, "amd", options, data);
+		
+		// Minify every file in the graph
+		if(minify) {
+			winston.info('Minifying...');
+			minifyGraph(dependencyGraph, options);
+			minifyGraph(stealconfig, options);
+		}
+
+		// Split the graph into two smaller graphs. One will contain the
+		// "mains" and their dependencies that need to be loaded right away.  
+		// The other will will be the bundles that are progressively loaded.
+		var splitGraphs = splitGraphByModuleNames(dependencyGraph, mains),
+			mainsGraph = splitGraphs["with"],
+			bundledGraph = splitGraphs.without;
+
+		winston.info('Calculating main bundle(s)...');
+		// Put everything into unique bundle graphs that have no waste. 
+		var mainBundles = makeBundle(mainsGraph);
+		// Combine bundles to reduce the number of total bundles that will need to be loaded
+		winston.info('Flattening main bundle(s)...');
+		flattenBundle(mainBundles,config.mainDepth || config.bundleDepth || 3);
+		// Break up bundles by buildType
+		var splitMainBundles = splitByBuildType(mainBundles);
+
+		var splitBundles = [];
+		if(!_.isEmpty(bundledGraph)) {
+			winston.info('Calculating progressively loaded bundle(s)...');
+			// Put everything into unique bundle graphs that have no waste. 
+			var bundles = makeBundle(bundledGraph);
+			// Combine bundles to reduce the number of total bundles that will need to be loaded
+			winston.info('Flattening progressively loaded bundle(s)...');
+			flattenBundle(bundles,config.bundleDepth || 3);
+			// Break up bundles by buildType
+			splitBundles = splitByBuildType(bundles);
+		}
+
+		
+		
+		// Every mainBundle needs to have @config and bundle configuration to know
+		// where everything is. Lets get those main bundles here while there is less to go through.
+
+		var mainJSBundles = mains.map(function(main){
+			return getBundleForOnly(splitMainBundles,main,"js");
+		});
+		
+		// Combine all bundles
+		var allBundles = splitMainBundles.concat(splitBundles);
+		// Name each bundle so we know what to call the bundle.
+		allBundles.forEach(nameBundle);
+		// Make sure the main bundle doesn't have an npm-normalized name
+		mainJSBundles.forEach(nameBundle.denpmed);
+
+		// Create a lookup object of the main bundle names so that they are
+		// excluded from the Bundles config
+		var mainJSBundleNames = {};
+		mainJSBundles.forEach(function(mainJSBundle){
+			mainJSBundleNames[mainJSBundle.name] = true;
+		});
+		
+		// Add @config and the bundleConfigNode to each main
+		mainJSBundles.forEach(function(mainJSBundle){
+			[].unshift.apply(mainJSBundle.nodes, stealconfig );
+			// Make config JS code so System knows where to look for bundles.
+			var configNode = makeBundlesConfig(allBundles, configuration, mainJSBundle, {
+				excludedBundles: mainJSBundleNames
+			});
+			mainJSBundle.nodes.unshift(configNode);
+			
+			if(options.bundleSteal) {
+				addStealToBundle(mainJSBundle, mainJSBundle.bundles[0], configuration);
+			}
+			// Traceur code requires a runtime.
+			var hasES6modules = hasES6(dependencyGraph);
+			if( hasES6modules ) {
+				addTraceurRuntime(mainJSBundle);
+			}
+			
+		});
+
+		// Mark bundles that are dirty so that they will be written to the file
+		// system.
+		markBundlesDirty(allBundles, data);
+
+		return {
+			bundles: allBundles,
+			configuration: configuration
+		};
+	}
+};

--- a/lib/stream/watch.js
+++ b/lib/stream/watch.js
@@ -1,0 +1,50 @@
+var chokidar = require("chokidar");
+
+module.exports = function(buildStream, rebuildStream, callback){
+	var watcher, addresses, allNodes;
+
+	function buildComplete(bundles){
+		allNodes = invert(bundles);
+		addresses = Object.keys(allNodes);
+		setupWatch();
+	}
+
+	function changed(event, address){
+		var node = allNodes[address];
+		callback(node);
+	}
+
+	function setupWatch(){
+		if(!watcher) {
+			watcher = chokidar.watch(addresses, { ignoreInitial: true });
+			watcher.on("all", changed);
+		} else {
+			watcher.unwatch(addresses);
+			watcher.add(addresses);
+		}
+	}
+
+	buildStream.on("data", buildComplete);
+
+	rebuildStream.on("error", function(error){
+		// If this is a missing file add it to our watch.
+		if(error.code === "ENOENT" && error.path) {
+			console.log("File not found:", error.path);
+			watcher.add(error.path);
+		}
+	});
+};
+
+// Given an array of bundles, inverts them into a table of addresses to nodes
+function invert(bundles){
+	var table = {};
+	bundles.forEach(function(bundle){
+		bundle.nodes.forEach(function(node){
+			if(node.load.address){
+				table[node.load.address.replace("file:", "")] = node;
+			}
+		});
+	});
+	return table;
+}
+

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "glob": "^4.3.5",
     "less": "^2.4.0",
     "lodash": "2.4.1",
+    "moment": "^2.10.2",
     "source-map": "git://github.com/bitovi/source-map#0.4.2-bitovi.0",
     "steal": "^0.8.0",
     "system-parse-amd": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "web": "http://bitovi.com/"
   },
   "dependencies": {
+    "chokidar": "^1.0.1",
     "clean-css": "3.1.8",
     "colors": "^0.6.2",
     "find-line-column": "^0.5.2",
@@ -18,6 +19,7 @@
     "source-map": "git://github.com/bitovi/source-map#0.4.2-bitovi.0",
     "steal": "^0.8.0",
     "system-parse-amd": "0.0.2",
+    "through2": "^0.6.5",
     "traceur": "0.0.87",
     "transpile": "^0.7.0",
     "uglify-js": "~2.4.13",

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -10,11 +10,14 @@ module.exports = function(grunt){
 		var buildOptions = options.buildOptions;
 
 		// Run the build with the provided options
-		build(system, buildOptions).then(function(){
-			grunt.log.writeln("Build was successful.");
+		var promise = build(system, buildOptions);
+		if(promise.then) {
+			promise.then(function(){
+				grunt.log.writeln("Build was successful.");
 
-			done();
-		});
+				done();
+			});
+		}
 		
 	});
 

--- a/test/basics/basics.js
+++ b/test/basics/basics.js
@@ -1,5 +1,5 @@
 steal('basics/module', function(module){
-	
+
 	if(window.QUnit) {
 		QUnit.ok(module, "got basics/module");
 		QUnit.equal(module.name, "module", "module name is right");

--- a/test/test.js
+++ b/test/test.js
@@ -239,12 +239,7 @@ describe("multi build", function(){
 
 
 			}, done);
-
-
-
 		});
-
-
 	});
 
 	it("should work with CommonJS", function(done){


### PR DESCRIPTION
The watch mode is a mode of the multi-build that continously builds as files in the dependency graph change. To use:

```shell
steal-tools --watch
```

This will use `package.json!npm` as the config (you can still pass `--config` and `--main` options if you want), do an intial build and watch for file changes which will trigger a rebuild.

Closes #80