### PR TITLE
Making bundleSteal option work for bundling a webworker with steal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ node_js:
 before_script:
   - npm install -g bower
   - bower install
+before_install:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,24 +4,50 @@ module.exports = function(grunt) {
 
   // Project configuration.
   grunt.initConfig({
-    simplemocha: {
-      app: {
-        src: ['test/test.js']
-      }
-    },
-    jshint: {
-      options: {
-        jshintrc: '.jshintrc'
-      },
-      lib: ['lib/**/*.js', 'tasks/**/*.js', 'Gruntfile.js']
-    },
-    release: {}
+	simplemocha: {
+		app: {
+			src: ['test/test.js']
+		}
+	},
+	jshint: {
+		options: {
+			jshintrc: '.jshintrc'
+		},
+		lib: ['lib/**/*.js', 'tasks/**/*.js', 'Gruntfile.js']
+	},
+	release: {},
+	"steal-build": {
+		"test-webworker": {
+			options: {
+				system: {
+					configMain: "@empty",
+					main: "worker",
+					baseUrl: __dirname + "/test/browser/webworker"
+				},
+				buildOptions: {
+					bundleSteal: true,
+					quiet: true
+				}
+			}
+		}
+	},
+	testee: {
+		tests: {
+			options: {
+				browsers: [ "firefox" ]
+			},
+			src: [ "test/browser/test.html" ]
+		}
+	}
   });
 
   grunt.registerTask('default', 'test');
   grunt.registerTask('test', [ 'jshint', 'simplemocha' ]);
+  grunt.registerTask("test:browser", [ "steal-build", "testee" ]);
 
   grunt.loadNpmTasks('grunt-simple-mocha');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-release');
+  grunt.loadNpmTasks('testee');
+  grunt.loadTasks("tasks");
 };

--- a/lib/bundle/add_steal.js
+++ b/lib/bundle/add_steal.js
@@ -5,6 +5,9 @@ var makeStealNode = require("../node/make_steal_node"),
 // makes it so this bundle loads steal
 module.exports = function(bundle, main, configuration){
 
-	bundle.nodes.unshift(makeNode("[production-config]","steal={env: 'production', configMain: '"+configuration.configMain+"'};"), makeStealNode(configuration), makeNode("[add-define]","window.define = System.amdDefine;"));
+	bundle.nodes.unshift(
+		makeNode("[production-config]","steal={env: 'production', configMain: '"+configuration.configMain+"'};"),
+		makeStealNode(configuration), makeNode("[add-define]","((typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) ? self : window).define = System.amdDefine;")
+	);
 	bundle.nodes.push( makeNode("[import-main-module]", "System.import('"+configuration.configMain+"').then(function() {\nSystem.import('"+main+"'); \n});") );
 };

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "jquery": ">2.0",
     "mocha": "1.18.2",
     "rimraf": "2.1",
+    "steal-qunit": "0.0.4",
     "zombie": "2.5.1"
   },
   "bin": {
@@ -66,5 +67,10 @@
   ],
   "scripts": {
     "test": "grunt test"
+  },
+  "system": {
+    "npmDependencies": [
+      "steal-qunit"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "mocha": "1.18.2",
     "rimraf": "2.1",
     "steal-qunit": "0.0.4",
+    "testee": "^0.2.0",
     "zombie": "2.5.1"
   },
   "bin": {
@@ -66,7 +67,7 @@
     }
   ],
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test && grunt test:browser"
   },
   "system": {
     "npmDependencies": [

--- a/test/browser/build.js
+++ b/test/browser/build.js
@@ -1,0 +1,9 @@
+var stealTools = require("../../index");
+
+stealTools.build({
+	configMain: "@empty",
+	main: "worker",
+	baseUrl: __dirname + "/webworker"
+}, {
+	bundleSteal: true
+});

--- a/test/browser/build.js
+++ b/test/browser/build.js
@@ -1,9 +1,0 @@
-var stealTools = require("../../index");
-
-stealTools.build({
-	configMain: "@empty",
-	main: "worker",
-	baseUrl: __dirname + "/webworker"
-}, {
-	bundleSteal: true
-});

--- a/test/browser/test.html
+++ b/test/browser/test.html
@@ -1,0 +1,1 @@
+<script src="../../node_modules/steal/steal.js" main="test/browser/test"></script>

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -1,0 +1,17 @@
+var qunit = require("steal-qunit");
+
+var makeIframe = function(src){
+	var iframe = document.createElement('iframe');
+	window.removeMyself = function(){
+		delete window.removeMyself;
+		document.body.removeChild(iframe);
+	};
+	document.body.appendChild(iframe);
+	iframe.src = src;
+};
+
+if(window.Worker) {
+	asyncTest("webworkers", function(){
+		makeIframe("webworker/prod.html");
+	});
+}

--- a/test/browser/webworker/dep.js
+++ b/test/browser/webworker/dep.js
@@ -1,0 +1,1 @@
+exports.foo = "bar";

--- a/test/browser/webworker/prod.html
+++ b/test/browser/webworker/prod.html
@@ -1,0 +1,22 @@
+<script>
+	window.QUnit = window.parent.QUnit;
+	window.removeMyself = window.parent.removeMyself;
+</script>
+<script>
+
+	var worker = new Worker("dist/bundles/worker.js");
+
+	worker.addEventListener("message", function(e){
+		
+	if(typeof window !== "undefined" && window.QUnit) {
+
+		QUnit.equal(e.data.foo, "bar", "worker event value is right");
+		
+		QUnit.start();
+		removeMyself();
+	} else {
+		console.log("HELLP", e);
+	}
+
+	});
+</script>

--- a/test/browser/webworker/worker.js
+++ b/test/browser/webworker/worker.js
@@ -1,0 +1,3 @@
+var dep = require("./dep");
+
+self.postMessage(dep);


### PR DESCRIPTION
Fixes #231 

Replaces the line:

```javascript
window.define = System.amdDefine;
```

with
```javascript
((typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) ? self : window).define = System.amdDefine;
```

...so that it can run in a web worker.

Adds a test to ensure it works. But not sure how to hook up the test to CI.