### PR TITLE
Update to source-map dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "less": "^2.4.0",
     "lodash": "2.4.1",
     "moment": "^2.10.2",
-    "source-map": "git://github.com/bitovi/source-map#0.4.2-bitovi.0",
+    "source-map": "git://github.com/bitovi/source-map#0.4.2-bitovi.1",
     "steal": "^0.9.1",
     "system-parse-amd": "0.0.2",
     "through2": "^0.6.5",


### PR DESCRIPTION
This updates us to a patched version of our source-map dependency. This is a workaround for an issue with uglify where it keeps the original source map and adds new mappings, resulting in more generated lines than lines in the final source, which would previously throw an exception during concat. The fix is to ignore the extra line mappings.