### PR TITLE
When bundling steal, merge global configuration

### DIFF
--- a/lib/bundle/add_steal.js
+++ b/lib/bundle/add_steal.js
@@ -6,8 +6,22 @@ var makeStealNode = require("../node/make_steal_node"),
 module.exports = function(bundle, main, configuration){
 
 	bundle.nodes.unshift(
-		makeNode("[production-config]","steal={env: 'production', configMain: '"+configuration.configMain+"'};"),
-		makeStealNode(configuration), makeNode("[add-define]","((typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) ? self : window).define = System.amdDefine;")
+		makeProductionConfigNode(configuration),
+		makeStealNode(configuration),
+		makeDefineNode()
 	);
 	bundle.nodes.push( makeNode("[import-main-module]", "System.import('"+configuration.configMain+"').then(function() {\nSystem.import('"+main+"'); \n});") );
 };
+
+function makeProductionConfigNode(configuration){
+	var configString = "steal = " + browserGlobal + ".steal || {};\n" +
+		"steal.env = \"production\";\n" +
+		"steal.configMain = \"" + configuration.configMain + "\";";
+	return makeNode("[production-config]", configString);
+}
+
+function makeDefineNode(){
+	return makeNode("[add-define]", browserGlobal + ".define = System.amdDefine;");
+}
+
+var browserGlobal = "((typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope) ? self : window)";

--- a/test/basics/prod-inst.html
+++ b/test/basics/prod-inst.html
@@ -1,0 +1,12 @@
+<div id="test-element">#test-element</div>
+<script>
+	steal = {
+		instantiated: {
+			"stealconfig.js": null
+		}
+	};
+</script>
+<script src="../dist/bundles/basics/basics.js"
+		data-base-url="../"
+        data-main="basics/basics"
+		data-env="production"></script>

--- a/test/test.js
+++ b/test/test.js
@@ -585,6 +585,43 @@ describe("multi build", function(){
 	
 	});
 
+	
+	it("System.instantiate works when bundling steal", function(done){
+		rmdir(__dirname+"/dist", function(error){
+			if(error){
+				done(error)
+			}
+
+			multiBuild({
+				config: __dirname+"/stealconfig.js",
+				main: "basics/basics"
+			}, {
+				bundleSteal: true,
+				quiet: true,
+				minify: false
+			}).then(function(data){
+				open("test/basics/prod-inst.html",function(browser, close){
+					find(browser,"MODULE", function(module){
+						assert(true, "module");
+
+						// We marked stealconfig.js as instantiated so it shouldn't have it's properties
+						var System = browser.window.System;
+						assert.equal(System.map["mapd/mapd"], undefined, "Mapping not applied");
+						
+						close();
+					}, close);
+				}, done);
+
+
+			}, done);
+
+
+
+		});
+	
+	});
+
+
 
 	it("Returns an error when building a main that doesn\'t exist", function(done){
 		var config = {


### PR DESCRIPTION
When bundling steal we add steal as a global at the top of the configuration, but we need to merge in changes made by setting a global `steal` object for configuration. This adds that, fixing #230