### PR TITLE
Remove an unneeded unwatching of dependencies

### DIFF
--- a/lib/stream/watch.js
+++ b/lib/stream/watch.js
@@ -10,7 +10,6 @@ module.exports = function(graphStream){
 		allNodes = invert(data.graph);
 		addresses = Object.keys(allNodes);
 
-		watcher.unwatch(addresses);
 		watcher.add(addresses);
 	}
 
@@ -23,7 +22,7 @@ module.exports = function(graphStream){
 	watcher.on("all", changed);
 
 	graphStream.on("data", updateWatch);
-	
+
 	return stream;
 };
 


### PR DESCRIPTION
Previously I was unwatching the addresses of the dependency graph before re-adding them. I was trying to avoid duplicate watch events. It turns out that this was causing a bug in Linux. Did some testing and the unwatch is not needed, there will not be duplicate events. Fixes #242