### PR TITLE
Make live-reload recover from syntax errors in es6 files

### DIFF
--- a/lib/graph/recycle.js
+++ b/lib/graph/recycle.js
@@ -65,8 +65,9 @@ module.exports = function(config){
 						return next(null, cachedData);
 					}
 					regenerate(moduleName, next);
-				}, function(){
-					regenerate(moduleName, next);
+				}, function(err){
+					err.moduleName = moduleName;
+					next(err);
 				});
 			} else {
 				regenerate(null, next);

--- a/lib/stream/live.js
+++ b/lib/stream/live.js
@@ -40,9 +40,17 @@ module.exports = function(config, options){
 		// Update our dependency graph
 		graphStream.write(moduleName);
 	}
-	
+
 	graphStream.once("data", function(){
 		console.error("Live-reload server listening on port", port);
+	});
+
+	graphStream.on("error", function(err){
+		if(err.moduleName) {
+			console.error("Oops! Error reloading", err.moduleName.red);
+		} else {
+			console.error(err);
+		}
 	});
 
 	initialGraphStream.write(config.main);

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "grunt-simple-mocha": "^0.4.0",
     "jquery": ">2.0",
     "mocha": "1.18.2",
+    "mock-fs": "^2.6.0",
     "rimraf": "2.1",
     "steal-qunit": "0.0.4",
     "testee": "^0.2.0",


### PR DESCRIPTION
This change makes live-reload catch errors that happen when there is a syntax error in an es6 file. Instead of crashing it will print a nice error message until you fix it.

![screen shot 2015-05-01 at 1 23 50 pm](https://cloud.githubusercontent.com/assets/361671/7434076/54e7a15a-f005-11e4-91f5-8cdf315de3b4.png)
