### PR TITLE
Support sideBundle: true as way to move modules into another bundle

### DIFF
--- a/lib/bundle/concat_source.js
+++ b/lib/bundle/concat_source.js
@@ -9,6 +9,8 @@ module.exports = function(bundle, sourceProp, excludePlugins){
 	var nodes = bundle.nodes.map(function(node){
 		var source = sourceNode(node, sourceProp);
 
+		// For plugins, only include them if they explicitly define
+		// includeInBuild
 		if(node.isPlugin && !node.value.includeInBuild) {
 			return {
 				node: node,

--- a/lib/graph/make_graph_with_bundles.js
+++ b/lib/graph/make_graph_with_bundles.js
@@ -29,10 +29,10 @@ function mergeIntoMasterAndAddBundle (masterGraph, newGraph, bundle) {
 }
 
 var makeBundleGraph = module.exports = function(config){
-	
+
 	// the names of everything we are going to load
 	var bundleNames = [];
-	
+
 	var cfg = _.clone(config, true);
 	if( Array.isArray(cfg.main) ) {
 		bundleNames = cfg.main;
@@ -44,17 +44,17 @@ var makeBundleGraph = module.exports = function(config){
 		.then(function(data){
 
 		// TODO I left off here, need to make sure main is normalized.
-		
+
 		var masterGraph = data.graph,
 			main = data.steal.System.main;
-		
+
 		// add the "main" bundle to everything currently on the main dependency graph;
-		addBundleOnEveryModule(masterGraph, main); 
-		
+		addBundleOnEveryModule(masterGraph, main);
+
 		// Get the bundles of the loader
 		var loader = data.steal.System;
 		bundleNames = bundleNames.concat(loader.bundle.slice(0));
-		
+
 		// Get the next bundle name and gets a graph for it.
 		// Merges those nodes into the masterGraph
 		var getNextGraphAndMerge = function(){
@@ -78,9 +78,9 @@ var makeBundleGraph = module.exports = function(config){
 				});
 			}
 		};
-		
+
 		return getNextGraphAndMerge();
-		
+
 	});
 };
 

--- a/lib/graph/pluck_only_descendant_of.js
+++ b/lib/graph/pluck_only_descendant_of.js
@@ -1,0 +1,42 @@
+var eachGraph = require("./each_dependencies");
+
+/**
+ * Pluck out descendants, who are only descendants, of a specific root node.
+ */
+module.exports = function(dependencyGraph, name){
+	var ancestorName = name;
+
+	// First collect a list of descendants
+	var descendants = {};
+	eachGraph(dependencyGraph, name, function(name){
+		descendants[name] = true;
+	});
+
+	// For each node in the graph, make sure the non-descendants
+	// don't have dependencies of any descendants.
+	var node;
+	for(name in dependencyGraph) {
+		if(!descendants[name]) {
+			node = dependencyGraph[name];
+			node.dependencies.forEach(function(depName){
+				if(depName !== ancestorName && (depName in descendants)) {
+					removeDescendants(depName);
+				}
+			});
+		}
+	}
+
+	function removeDescendants(name){
+		delete descendants[name];
+		eachGraph(dependencyGraph, name, function(depName){
+			delete descendants[depName];
+		});
+	}
+
+	var newGraph = {};
+	for(name in descendants) {
+		newGraph[name] = dependencyGraph[name];
+		delete dependencyGraph[name];
+	}
+	return newGraph;
+};

--- a/lib/graph/unbundle.js
+++ b/lib/graph/unbundle.js
@@ -1,0 +1,26 @@
+var pluckOnlyDescendantOf = require("./pluck_only_descendant_of");
+
+/*
+ * Unbundle dependencies that are marked as bundle: false
+ */
+module.exports = function(dependencyGraph){
+	var graphs = [];
+
+	var node, unbundledGraph;
+	for(var name in dependencyGraph){
+		node = dependencyGraph[name];
+		if(node && node.load.metadata && node.load.metadata.sideBundle) {
+			unbundledGraph = pluckOnlyDescendantOf(dependencyGraph, name);
+			markBundleOf(unbundledGraph, name);
+			graphs.push(unbundledGraph);
+		}
+	}
+
+	return graphs;
+};
+
+function markBundleOf(graph, bundleName){
+	for(var name in graph) {
+		graph[name].bundles = [bundleName];
+	}
+}

--- a/lib/stream/build.js
+++ b/lib/stream/build.js
@@ -3,7 +3,7 @@
 # lib/build/multi.js
 
 The bundled build works by loading the _main_ module and all of its
-dependencies and then all of the `System.bundle` modules 
+dependencies and then all of the `System.bundle` modules
 and their dependencies. It makes a dependency graph that looks like:
 
 ```js
@@ -34,7 +34,7 @@ Here's an example:
   "can/util": {
     load: {
       name: "can/util",
-      source: "define(['jquery'], function($){ ... })" 
+      source: "define(['jquery'], function($){ ... })"
     },
     dependencies: ["jquery"],
     bundles: ["profile","login"]
@@ -44,7 +44,7 @@ Here's an example:
 
 A `Load` is a ES6 load record.
 
-A `Node` is an object that contains the load and other 
+A `Node` is an object that contains the load and other
 useful information. The build tools only write to `Node` to keep `Load` from being changed.
 
 It manipulates this graph and eventually creates "bundle" graphs.  Bundle graphs look like:
@@ -52,9 +52,9 @@ It manipulates this graph and eventually creates "bundle" graphs.  Bundle graphs
      {
        size: 231231,
        nodes: [node1, node2, ...],
-       bundles: [bundleName1, bundleName2]	
+       bundles: [bundleName1, bundleName2]
      }
-     
+
 The nodes in those bundles are written to the filesystem.
 
 */
@@ -79,7 +79,8 @@ var winston = require('winston'),
 	getBundleForOnly = require("../bundle/get_for_only"),
 	findBundles = require("../loader/find_bundle"),
 	through = require("through2"),
-	markBundlesDirty = require("../bundle/mark_as_dirty");
+	markBundlesDirty = require("../bundle/mark_as_dirty"),
+	unbundle = require("../graph/unbundle");
 
 
 module.exports = function(config, options){
@@ -128,14 +129,14 @@ module.exports = function(config, options){
 
 		// Remove steal dev from production builds.
 		pluck(dependencyGraph,"@dev");
-		
-		// Adds an `order` property to each `Node` so we know which modules.  
+
+		// Adds an `order` property to each `Node` so we know which modules.
 		// The lower the number the lower on the dependency tree it is.
 		// For example, jQuery might have `order: 0`.
 		mains.forEach(function(moduleName){
 			order(dependencyGraph, moduleName);
 		});
-		
+
 		findBundles(data.loader).forEach(function(moduleName){
 			order(dependencyGraph, moduleName);
 		});
@@ -149,7 +150,7 @@ module.exports = function(config, options){
 		// should be able to work without steal.js.
 		winston.info('Transpiling...');
 		transpile(dependencyGraph, "amd", options, data);
-		
+
 		// Minify every file in the graph
 		if(minify) {
 			winston.info('Minifying...');
@@ -157,15 +158,19 @@ module.exports = function(config, options){
 			minifyGraph(stealconfig, options);
 		}
 
+		// Get unbundled graphs, these are graphs of modules that are marked
+		// to not be bundled, they will be put into their own bundles later.
+		var unbundledGraphs = unbundle(dependencyGraph);
+
 		// Split the graph into two smaller graphs. One will contain the
-		// "mains" and their dependencies that need to be loaded right away.  
+		// "mains" and their dependencies that need to be loaded right away.
 		// The other will will be the bundles that are progressively loaded.
 		var splitGraphs = splitGraphByModuleNames(dependencyGraph, mains),
 			mainsGraph = splitGraphs["with"],
 			bundledGraph = splitGraphs.without;
 
 		winston.info('Calculating main bundle(s)...');
-		// Put everything into unique bundle graphs that have no waste. 
+		// Put everything into unique bundle graphs that have no waste.
 		var mainBundles = makeBundle(mainsGraph);
 		// Combine bundles to reduce the number of total bundles that will need to be loaded
 		winston.info('Flattening main bundle(s)...');
@@ -176,7 +181,7 @@ module.exports = function(config, options){
 		var splitBundles = [];
 		if(!_.isEmpty(bundledGraph)) {
 			winston.info('Calculating progressively loaded bundle(s)...');
-			// Put everything into unique bundle graphs that have no waste. 
+			// Put everything into unique bundle graphs that have no waste.
 			var bundles = makeBundle(bundledGraph);
 			// Combine bundles to reduce the number of total bundles that will need to be loaded
 			winston.info('Flattening progressively loaded bundle(s)...');
@@ -185,17 +190,23 @@ module.exports = function(config, options){
 			splitBundles = splitByBuildType(bundles);
 		}
 
-		
-		
 		// Every mainBundle needs to have @config and bundle configuration to know
 		// where everything is. Lets get those main bundles here while there is less to go through.
 
 		var mainJSBundles = mains.map(function(main){
 			return getBundleForOnly(splitMainBundles,main,"js");
 		});
-		
+
+		// Create unbundled bundles, for modules marked as sideBundle: true
+		var unbundledBundles = unbundledGraphs.reduce(function(bundles, graph){
+			bundles.push.apply(bundles, makeBundle(graph));
+			return bundles;
+		}, []);
+		unbundledBundles = splitByBuildType(unbundledBundles);
+
 		// Combine all bundles
 		var allBundles = splitMainBundles.concat(splitBundles);
+		allBundles = allBundles.concat.apply(allBundles, unbundledBundles);
 		// Name each bundle so we know what to call the bundle.
 		allBundles.forEach(nameBundle);
 		// Make sure the main bundle doesn't have an npm-normalized name
@@ -207,7 +218,7 @@ module.exports = function(config, options){
 		mainJSBundles.forEach(function(mainJSBundle){
 			mainJSBundleNames[mainJSBundle.name] = true;
 		});
-		
+
 		// Add @config and the bundleConfigNode to each main
 		mainJSBundles.forEach(function(mainJSBundle){
 			[].unshift.apply(mainJSBundle.nodes, stealconfig );
@@ -216,7 +227,7 @@ module.exports = function(config, options){
 				excludedBundles: mainJSBundleNames
 			});
 			mainJSBundle.nodes.unshift(configNode);
-			
+
 			if(options.bundleSteal) {
 				addStealToBundle(mainJSBundle, mainJSBundle.bundles[0], configuration);
 			}
@@ -225,7 +236,7 @@ module.exports = function(config, options){
 			if( hasES6modules ) {
 				addTraceurRuntime(mainJSBundle);
 			}
-			
+
 		});
 
 		// Mark bundles that are dirty so that they will be written to the file

--- a/test/side_bundle/b.js
+++ b/test/side_bundle/b.js
@@ -1,0 +1,4 @@
+var c = require("c");
+var d = require("d");
+
+module.exports = "b";

--- a/test/side_bundle/c.js
+++ b/test/side_bundle/c.js
@@ -1,0 +1,1 @@
+module.exports = "c";

--- a/test/side_bundle/d.js
+++ b/test/side_bundle/d.js
@@ -1,0 +1,1 @@
+module.exports = "d";

--- a/test/side_bundle/main.js
+++ b/test/side_bundle/main.js
@@ -1,0 +1,6 @@
+var b = require("b");
+var c = require("c");
+
+window.MODULE = {
+	b: b
+};

--- a/test/side_bundle/package.json
+++ b/test/side_bundle/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "ignore_true",
+	"main": "main.js",
+	"version": "0.0.1",
+	"system": {
+		"meta": {
+			"./b": {
+				"sideBundle": true
+			}
+		}
+	}
+}

--- a/test/side_bundle/prod.html
+++ b/test/side_bundle/prod.html
@@ -1,0 +1,4 @@
+<script src="../../bower_components/steal/steal.js"
+	data-env="production"
+	data-config="./package.json!npm"
+	data-main="main"></script>

--- a/test/test.js
+++ b/test/test.js
@@ -876,6 +876,31 @@ describe("multi build", function(){
 		});
 	});
 
+	it("sideBundle: true will move a module into a side bundle", function(done){
+		rmdir(__dirname+"/side_bundle/dist", function(error){
+			if(error) return done(error);
+
+			multiBuild({
+				config: __dirname + "/side_bundle/package.json!npm"
+			}, {
+				quiet: true,
+				minify: false
+			}).then(function(){
+				open("test/side_bundle/prod.html", function(browser, close){
+					find(browser, "MODULE", function(module){
+						var loader = browser.window.System;
+
+						comparify(loader.bundles, {
+							"bundles/b": [ "d", "b" ]
+						}, true);
+
+						close();
+					}, close);
+				}, done);
+			});
+		});
+	});
+
 });
 
 describe("multi build with plugins", function(){


### PR DESCRIPTION
This adds the ability to exclude a module from the normal bundling algorithm  with meta.

```js
System.config({
  meta: {
    "some/module": {
      sideBundle: true
    }
  }
});
```