### PR TITLE
Support export with module.exports

### DIFF
--- a/lib/bundle/add_global_shim.js
+++ b/lib/bundle/add_global_shim.js
@@ -4,8 +4,8 @@ var makeNode = require("../node/make_node"),
 
 // makes it so this bundle loads steal
 module.exports = function(bundle, options){
-	
-	
+
+
 	var exports = options.exports; // ? exportsForDependencies(bundle.nodes, options.exports) : {};
 	var source = "("+shim.toString()+")("+JSON.stringify(exports)+",window)";
 	var start = makeNode("[global-shim-start]", source);
@@ -19,10 +19,10 @@ module.exports = function(bundle, options){
 	bundle.nodes.push(end);
 };
 
-// This only includes exports for loads in the bundle and their dependencies. 
+// This only includes exports for loads in the bundle and their dependencies.
 /*var exportsForDependencies = function(bundle, allExports){
 	var exports = {};
-	
+
 	bundle.forEach(function(node){
 		if(allExports[node.load.name]){
 			exports[node.load.name] = allExports[node.load.name];
@@ -72,10 +72,13 @@ var shim = function(exports, global){
 			};
 			args.push(require, module.exports, module);
 		}
-		// Babel uses only the exports objet
+		// Babel uses the exports and module object.
 		else if(!args[0] && deps[0] === "exports") {
 			module = { exports: {} };
 			args[0] = module.exports;
+			if(!args[1] && deps[1] === "module") {
+				args[1] = module;
+			}
 		}
 
 		global.define = origDefine;

--- a/test/pluginifier_builder_helpers/global.html
+++ b/test/pluginifier_builder_helpers/global.html
@@ -1,16 +1,16 @@
 <html>
 	<head>
-		
+
 	</head>
 	<body>
-		
+
 		<div id='tabs'></div>
 		<script src="./node_modules/jquery/dist/jquery.js"></script>
 		<script src="./dist/global/tabs.js"></script>
 		<script>
 			$("#tabs").tabs();
 			_define("foo",["tabs"], function(tabs){
-				window.TABS = tabs["default"];
+				window.TABS = tabs["default"] || tabs;
 			});
 		</script>
 		<script>
@@ -21,7 +21,7 @@
 			  document.head.appendChild(style);
 			  window.WIDTH = $("#tabs").width();
 			}
-			
+
 			var oReq = new XMLHttpRequest();
 			oReq.onload = reqListener;
 			oReq.open("get", "./dist/global/tabs.css", true);

--- a/test/test.js
+++ b/test/test.js
@@ -1797,10 +1797,23 @@ describe("export", function(){
 				"outputs": {
 					"+cjs": {},
 					"+amd": {},
-					"+global-js": {},
+					"+global-js": {
+						exports: {
+							"jquery": "jQuery"
+						}
+					},
 					"+global-css": {}
 				}
-			}).then(done, done);
+			})
+			.then(function() {
+				open("test/pluginifier_builder_helpers/global.html", function(browser, close) {
+					find(browser,"WIDTH", function(width){
+						assert.equal(width, 200, "width of element");
+						assert.ok(browser.window.TABS, "got tabs");
+						close();
+					}, close);
+				}, done);
+			}, done);
 		});
 
 	});


### PR DESCRIPTION
Babel spits out AMD code that makes use of an `exports` and `module` object.  This is different from other cjs->amd transpilation with uses `exports`, `module`, and `require`. Since Babel doesn't use `require` we need to shim this behavior.  It's as simple as checking the names of the arguments and that there is not an existing import for them. Fixes #189