### PR TITLE
denpm bundle names

### DIFF
--- a/lib/build/transform.js
+++ b/lib/build/transform.js
@@ -2,7 +2,7 @@ var makeGraph = require("../graph/make_graph"),
 	makeBundleFromModuleName = require("../graph/get"),
 	concatSource = require("../bundle/concat_source"),
 	mapDependencies = require("../graph/map_dependencies"),
-	
+
 	logging = require('../logger'),
 	hasES6 = require('../graph/has_es6'),
 	_ = require('lodash'),
@@ -17,7 +17,7 @@ var makeGraph = require("../graph/make_graph"),
 	nameBundle = require("../bundle/name"),
 	makeConfiguration = require("../configuration/make"),
 	addSourceMapUrl = require("../bundle/add_source_map_url");
-	
+
 var toss = function(e){
 	setTimeout(function(){
 		throw e;
@@ -60,21 +60,21 @@ var transformImport = function(config, transformOptions){
 			if(typeof moduleNames === "string"){
 				moduleNames = [moduleNames];
 			}
-			
+
 			moduleNames.forEach(function(moduleName){
 				if(!data.graph[moduleName]){
 					throw new Error("Can't find module '" + moduleName + "' in graph.");
 				}
 			});
 			var nodesInBundle;
-			
+
 			// get nodes
 			if(options.ignoreAllDependencies) {
-				
+
 				nodesInBundle = moduleNames.map(function(moduleName){
 					return data.graph[moduleName];
 				});
-					
+
 			} else {
 				// get all nodes that are dependencies of moduleName
 				var nodes = makeBundleFromModuleName(data.graph, moduleNames);
@@ -83,41 +83,41 @@ var transformImport = function(config, transformOptions){
 				// get only the nodes that should be in the bundle.
 				nodesInBundle = transformImport.notIgnored(nodes, ignores);
 			}
-			
+
 			// resets the active source to be worked from.
 			removeActiveSourceKeys(nodesInBundle, options);
 
 			// #### clean
-			// Clean first 
+			// Clean first
 			if(options.removeDevelopmentCode) {
 				winston.debug('Cleaning...');
-				clean(nodesInBundle, options);	
+				clean(nodesInBundle, options);
 			}
 			// Minify would make sense to do next as it is expensive.  But it
 			// makes transpile hard to debug.
-			
+
 			// #### transpile
 			winston.debug('Transpiling...');
 			options.sourceMapPath = configuration.bundlesPath;
-			transpile(nodesInBundle, 
-				options.format === "global" ? "amd" : options.format, 
-				options.format === "global" ? _.assign(_.clone(options),{namedDefines: true})  : options, 
+			transpile(nodesInBundle,
+				options.format === "global" ? "amd" : options.format,
+				options.format === "global" ? _.assign(_.clone(options),{namedDefines: true})  : options,
 				data);
-			
-			
+
+
 			// #### minify
 			if(options.minify) {
 				winston.debug('Minifying...');
 				minify(nodesInBundle);
 			}
-			
+
 			var bundle = {
 				bundles: moduleNames,
 				nodes: nodesInBundle,
 				buildType: nodesInBundle[0].load.metadata.buildType || "js"
 			};
-			nameBundle.denpmed(bundle);
-			
+			nameBundle(bundle);
+
 			// add shim if global
 			// TODO: document noGlobalShim
 			if(options.format === "global" && !options.noGlobalShim) {
@@ -134,7 +134,7 @@ var transformImport = function(config, transformOptions){
 			if(options.sourceMaps) {
 				addSourceMapUrl(bundle);
 			}
-			
+
 			return bundle.source;
 		};
 
@@ -142,12 +142,12 @@ var transformImport = function(config, transformOptions){
 		transform.graph = data.graph;
 		transform.loader = data.loader;
 		return transform;
-		
-		
+
+
 	}).catch(function(e){
 		toss(e);
 	});
-	
+
 };
 
 
@@ -166,7 +166,7 @@ var matches = function(rules, name, load){
 	} else if( typeof rules === "function") {
 		return rules(name, load);
 	}
-	
+
 };
 
 transformImport.getAllIgnores = function(baseIgnores, graph) {

--- a/lib/bundle/name.js
+++ b/lib/bundle/name.js
@@ -1,5 +1,17 @@
 var crypto = require('crypto');
 
+var npmNameExp = /.+@.+#.+/;
+function isNpm(name) {
+	return npmNameExp.test(name);
+}
+
+function deNpm(name) {
+	if(!isNpm(name)) return name;
+	var dirName = name.substr(0, name.indexOf("/"));
+	var modulePath = name.substr(name.indexOf("#")+1);
+	return dirName+"/"+modulePath;
+}
+
 var filename = function(uri){
 		var lastSlash = uri.lastIndexOf("/"),
 			matches = ( lastSlash == -1 ? uri : uri.substr(lastSlash+1) ).match(/^[\w-\s\.]+/);
@@ -56,7 +68,7 @@ function getName(bundle) {
 
 	if(!usedBundleNames[shortened]){
 		usedBundleNames[shortened] = true;
-		return dirName+shortened+buildTypeSuffix;
+		return deNpm(dirName+shortened+buildTypeSuffix);
 	} else if(shortened.length > 50){
 		return dirName+shortened.substr(0,50)+"-"+bundleNames.length+"-"+(bundleCounter++)+buildTypeSuffix;
 	} else {
@@ -64,17 +76,8 @@ function getName(bundle) {
 	}
 }
 
-function denpmed(bundle) {
-	var name = getName(bundle);
-	if(/.+@.+#.+/.test(name)) {
-		bundle.name = name.substr(name.lastIndexOf("#") + 1);
-	}
-	return bundle.name;
-}
-
 exports = module.exports = function(bundle) {
 	bundle.name = getName(bundle);
 };
 
 exports.getName = getName;
-exports.denpmed = denpmed;

--- a/lib/stream/build.js
+++ b/lib/stream/build.js
@@ -209,8 +209,6 @@ module.exports = function(config, options){
 		allBundles = allBundles.concat.apply(allBundles, unbundledBundles);
 		// Name each bundle so we know what to call the bundle.
 		allBundles.forEach(nameBundle);
-		// Make sure the main bundle doesn't have an npm-normalized name
-		mainJSBundles.forEach(nameBundle.denpmed);
 
 		// Create a lookup object of the main bundle names so that they are
 		// excluded from the Bundles config

--- a/test/test.js
+++ b/test/test.js
@@ -2165,6 +2165,10 @@ describe("npm package.json builds", function(){
 				quiet: true,
 				minify: false
 			}).then(function(){
+				// Make sure they are named correctly.
+				assert(fs.existsSync(__dirname + "/npm/dist/bundles/two.js"),
+									 "two bundle in the right place");
+
 				// open the prod page and make sure
 				// and make sure the module loaded successfully
 				open("test/npm/prod-bundle.html", function(browser, close){


### PR DESCRIPTION
This change makes sure that bundle names remove the npm qualities so that it's a flat bundle name.

The reason this change is necessarily is that in a Web Worker it doesn't recognize the \# character when doing an XHR request.