### PR TITLE
Export option ignore: false

### DIFF
--- a/doc/types/export-output.md
+++ b/doc/types/export-output.md
@@ -25,6 +25,8 @@ location.
   @param {Load|Array<Load>} load The module load record, or module load records, being written by this output. 
   @param {Loader} System The System loader used by Steal to load all of these modules.  All configuration
   should be available on it.
+ 
+@option {Array<moduleName>|Boolean} [ignore] Modules that should be ignored and not included in the output. For the [steal-tools/lib/build/helpers/global] helper providing `false` for this option will not ignore modules defined in `node_modules` as is done by default.
 
 @body
 

--- a/lib/build/helpers/cjs.js
+++ b/lib/build/helpers/cjs.js
@@ -8,21 +8,21 @@ var path = require('path'),
 /**
  * @module {function} steal-tools/lib/build/helpers/cjs cjs
  * @parent steal-tools.helpers
- * 
+ *
  * Helpers that make exporting to CJS projects easier.
- * 
+ *
  * @signature `"+cjs": { ... OVERWRITES ... }`
- * 
+ *
  * Adds helpers that export modules to a CJS format.
- * 
+ *
  * @body
- * 
+ *
  * ## Use
- * 
+ *
  * Adding "+cjs" to a [steal-tools.export.output] name will mixin
  * default [steal-tools.export.output] and [steal-tools.transform.options]
  * values that export modules to a CommonJS format.
- * 
+ *
  * ```
  * outputs: {
  *   "+cjs": {},
@@ -31,20 +31,20 @@ var path = require('path'),
  *   }
  * }
  * ```
- * 
+ *
  * This mixes in the following default values:
- * 
+ *
  * - [steal-tools/lib/build/helpers/cjs.graphs graphs] - Writes out System.main and all of its dependencies.
  * - [steal-tools/lib/build/helpers/cjs.format format] - Writes out all modules as CJS.
  * - [steal-tools/lib/build/helpers/cjs.normalize normalize] - Leaves moduleName references that reference modules in node_modules alone; makes
  *   all other moduleName references relative.
  * - [steal-tools/lib/build/helpers/cjs.dest dest] - Writes out each module in `[baseURL]/dist/cjs`.
  * - [steal-tools/lib/build/helpers/cjs.ignore ignore] - Ignores everything in node_modules.
- * 
- * You can overwrite or alter the behavior of these default values by adding a value in 
+ *
+ * You can overwrite or alter the behavior of these default values by adding a value in
  * the [steal-tools.export.output].
  * The following writes out dest in a different location:
- * 
+ *
  * ```
  * outputs: {
  *   "+cjs": {
@@ -52,18 +52,18 @@ var path = require('path'),
  *   }
  * }
  * ```
- * 
- * The behavior for overwriting [steal-tools.export.output] values is 
+ *
+ * The behavior for overwriting [steal-tools.export.output] values is
  * documented in the default value API pages.
- * 
+ *
  */
 module.exports = baseHelper.makeHelper({
 	/**
 	 * @function
-	 * 
+	 *
 	 * By default, writes out System.main and all of its dependencies. Defaults to "graphs"
 	 * default behavior if anything else is provided.
-	 * 
+	 *
 	 * @param {function|Array<moduleName>} [modules] An array of modules to overide the main file.
 	 */
 	graphs: function(modules){
@@ -79,7 +79,7 @@ module.exports = baseHelper.makeHelper({
 	},
 	/**
 	 * @function
-	 * 
+	 *
 	 * Returns "cjs".
 	 */
 	format: function(){
@@ -90,19 +90,19 @@ module.exports = baseHelper.makeHelper({
 	},
 	/**
 	 * @function
-	 * 
+	 *
 	 * By default, makes everything not in node_modules relative. It also
 	 * adds a ".js" or ".css" to files not ending with ".js" or ".css". If a function is provided,
 	 * it will overwrite this behavior.
-	 * 
+	 *
 	 */
 	normalize: function(aliases){
 		if(typeof aliases === "function") {
 			return aliases;
 		}
-		
+
 		aliases = aliases || {};
-		
+
 		return function(depName, depLoad, curName, curLoad, loader){
 			if(aliases[depName]) {
 				return aliases[depName];
@@ -115,14 +115,14 @@ module.exports = baseHelper.makeHelper({
 					depName = "./"+depName;
 				}
 			}
-			
+
 			// if it ends in /
 			if(depName[depName.length -1] === "/") {
 				var parts = depName.split("/");
 				parts[parts.length -1] = parts[parts.length -2];
 				depName = parts.join("/");
 			}
-			
+
 			// if the path is already relative ... good ... keep it that way
 			if(depName[0] === ".") {
 				depName = path.dirname(depName)+"/"+baseHelper.basename(depLoad);
@@ -141,25 +141,25 @@ module.exports = baseHelper.makeHelper({
 				}
 			}
 			// if two relative paths that are not in node_modules
-			
+
 			return depName;
 		};
-		
+
 	},
 	/**
 	 * @function dest
-	 * 
+	 *
 	 * By default, writes  out every module in `[baseURL]/dist/cjs`.  And adds a ".js" or ".css" to
 	 * files not ending with ".js" or ".css".
-	 * 
-	 * @param {String} [path] If provided, changes the location where files are written out. 
+	 *
+	 * @param {String} [path] If provided, changes the location where files are written out.
 	 */
 	dest: baseHelper.makeDest("dist/cjs"),
 	/**
-	 * @function 
-	 * 
+	 * @function
+	 *
 	 * Ignores everything in _node_modules_.
-	 * 
+	 *
 	 * @param {*} additional "ignores" that should be added.
 	 */
 	ignore: function(additional){

--- a/lib/build/helpers/global.js
+++ b/lib/build/helpers/global.js
@@ -8,25 +8,25 @@ var npmUtils = require("steal/ext/npm-utils");
 /**
  * @module {function} steal-tools/lib/build/helpers/global global
  * @parent steal-tools.helpers
- * 
- * Helpers that make exporting to [syntax.global] formats easier. 
- * 
+ *
+ * Helpers that make exporting to [syntax.global] formats easier.
+ *
  * @signature `"+global-js": { ... OVERWRITES ... }`
- * 
+ *
  * Exports all JS into a single file.
- * 
+ *
  * @signature `"+global-css": { ... OVERWRITES ... }`
- * 
+ *
  * Exports all CSS into a single file.
- * 
+ *
  * @body
- * 
+ *
  * ## Use
- * 
+ *
  * Add in `+global-js` and `+global-css` in an output name to build
  * a single file with all of the module and its dependencies JS and CSS
  * that is not in _node_modules_.
- * 
+ *
  * ```
  * stealTools.export({
  *   system: {
@@ -48,11 +48,11 @@ var make = function(buildType){
 		},
 		/**
 		 * @function dest
-		 * 
+		 *
 		 * By default, writes  out every module in `[baseURL]/dist/global`.  And adds a ".js" or ".css" to
 		 * files not ending with ".js" or ".css".
-		 * 
-		 * @param {String} [path] If provided, changes the location where files are written out. 
+		 *
+		 * @param {String} [path] If provided, changes the location where files are written out.
 		 */
 		dest: function(loc){
 			return function(moduleName, moduleData, load, System){
@@ -65,17 +65,20 @@ var make = function(buildType){
 						var pkg = JSON.parse( fs.readFileSync( path.join( baseRoot, "package.json" ) ) );
 						name = pkg.name;
 					} catch(e) {
-						name = path.basename(baseRoot); 
+						name = path.basename(baseRoot);
 					}
 					return path.join(baseRoot,"dist/global",name+"."+buildType);
 				}
 			};
 		},
 		ignore: function(items){
-			return cjs.ignore(items).concat([function(name, load){
+			var cssIgnore = [function(name, load){
 				var bt = load.metadata.buildType || "js";
 				return bt !== buildType;
-			}]);
+			}];
+
+			// Support ignore: false for globals
+			return items === false ? cssIgnore : cjs.ignore(items).concat(cssIgnore);
 		},
 		useNormalizedDependencies: function(){
 			return false;
@@ -98,13 +101,13 @@ var make = function(buildType){
 					} else {
 						name = depLoad.name;
 					}
-					
+
 					if( name === npmUtils.pkg.main(pkg) ) {
 						res = packageName;
 					} else {
 						res = packageName+"/"+name;
 					}
-					
+
 					return res;
 				}
 			};

--- a/test/pluginifier_builder_helpers/global-all.html
+++ b/test/pluginifier_builder_helpers/global-all.html
@@ -1,0 +1,22 @@
+<html>
+	<head>
+
+	</head>
+	<body>
+
+		<div id='tabs'></div>
+		<!-- jQuery should be included in the build
+		<script src="./node_modules/jquery/dist/jquery.js"></script>
+		-->
+		<script>
+			steal = { config: function(){} };
+		</script>
+		<script src="./dist/global/tabs.js"></script>
+		<script>
+			_define("foo",["tabs"], function(tabs){
+				window.TABS = tabs["default"] || tabs;
+			});
+			$("#tabs").tabs();
+		</script>
+	</body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -1886,6 +1886,34 @@ describe("export", function(){
 			}, done);
 		});
 
+		it("ignore: false will not ignore node_modules for globals", function(done){
+			this.timeout(10000);
+			stealExport({
+				system: {
+					config: __dirname + "/pluginifier_builder_helpers/package.json!npm",
+					meta: {
+						jquery: { format: "global" }
+					}
+				},
+				options: { quiet: true },
+				outputs: {
+					"+global-js": {
+						ignore: false,
+						exports: {
+							"jquery": "jQuery"
+						}
+					}
+				}
+			}).then(function(){
+				open("test/pluginifier_builder_helpers/global-all.html", function(browser, close) {
+					find(browser, "TABS", function(width){
+						assert.ok(browser.window.TABS, "got tabs");
+						close();
+					}, close);
+				}, done);
+			}, done);
+		});
+
 	});
 
 });


### PR DESCRIPTION
This allows when using the global-js helper to prevent ignoring of node_modules dependencies.