### PR TITLE
Set the env to "build" while building

### DIFF
--- a/lib/graph/make_graph.js
+++ b/lib/graph/make_graph.js
@@ -23,6 +23,7 @@ module.exports = function(config, options){
 	var localSteal = steal.clone();
 	addParseAMD( localSteal.System );
 
+	localSteal.System.config({ env: "development,build" });
 	localSteal.System.config(config);
 	localSteal.System.systemName = (localSteal.System.systemName||"")+"-local";
 	// This version of steal, and it's System can be used to load
@@ -45,7 +46,7 @@ module.exports = function(config, options){
 	// Except that it does not have a System.main so `startup` will
 	// not load the main module.  But it will load @config and @dev.
 	delete buildSteal.System.main;
-	buildSteal.System.env = "build";
+	buildSteal.System.config({ env: "build" });
 
 	// Set the build as the global objects
 	global.steal = buildSteal;


### PR DESCRIPTION
This updates the BuildSystem and LocalSystem to have an env of "build" during the build process. This is so scripts can use loader.envMap to see what environments are running and configure accordingly.