### PR TITLE
Correctly name bundles that use directories.lib

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "steal-tools",
   "version": "0.11.0-pre.6",
   "devDependencies": {
-    "steal": "^0.11.0-pre.0",
+    "steal": "^0.11.0-pre.1",
     "jquery": "~1.10.0",
     "less" : "^2.4.0"
   }

--- a/lib/bundle/name.js
+++ b/lib/bundle/name.js
@@ -7,9 +7,8 @@ function isNpm(name) {
 
 function deNpm(name) {
 	if(!isNpm(name)) return name;
-	var dirName = name.substr(0, name.indexOf("/"));
 	var modulePath = name.substr(name.indexOf("#")+1);
-	return dirName+"/"+modulePath;
+	return modulePath;
 }
 
 var filename = function(uri){
@@ -59,6 +58,12 @@ function getName(bundle) {
 		var plugin = pluginPart(shortened);
 		if(plugin) {
 			shortened = pluginResource(shortened);
+			// This is a project using directories.lib
+			// and needs to be packageName/modulePath
+			if(isNpm(shortened)) {
+				var pkgName = shortened.substr(0, shortened.indexOf("@"));
+				shortened = pkgName + "/" + deNpm(shortened);
+			}
 			shortened = shortened.substr(0, shortened.indexOf("."));
 		}
 	}
@@ -68,7 +73,7 @@ function getName(bundle) {
 
 	if(!usedBundleNames[shortened]){
 		usedBundleNames[shortened] = true;
-		return deNpm(dirName+shortened+buildTypeSuffix);
+		return dirName+deNpm(shortened+buildTypeSuffix);
 	} else if(shortened.length > 50){
 		return dirName+shortened.substr(0,50)+"-"+bundleNames.length+"-"+(bundleCounter++)+buildTypeSuffix;
 	} else {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "moment": "^2.10.2",
     "pdenodeify": "^0.1.0",
     "source-map": "git://github.com/bitovi/source-map#0.4.2-bitovi.1",
-    "steal": "^0.11.0-pre.0",
+    "steal": "^0.11.0-pre.1",
     "steal-bundler": "^0.2.0",
     "system-parse-amd": "0.0.2",
     "through2": "^0.6.5",

--- a/test/npm-directories/package.json
+++ b/test/npm-directories/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "npm-dependencies",
+  "main": "npm-dependencies/main.txt!npm-dependencies/plug",
+  "version": "1.0.0",
+  "system": {
+    "directories": {
+      "lib": "src"
+    },
+    "bundle": [
+      "npm-dependencies/other"
+    ]
+  }
+}

--- a/test/npm-directories/prod.html
+++ b/test/npm-directories/prod.html
@@ -1,0 +1,4 @@
+<script src="../../bower_components/steal/steal.js"
+	env="production"
+	data-config="./package.json!npm"
+	main="npm-dependencies/main.txt!npm-dependencies/plug"></script>

--- a/test/npm-directories/src/main.txt
+++ b/test/npm-directories/src/main.txt
@@ -1,0 +1,1 @@
+window.MODULE = module.exports = "hello world";

--- a/test/npm-directories/src/other.js
+++ b/test/npm-directories/src/other.js
@@ -1,0 +1,1 @@
+module.exports = "another";

--- a/test/npm-directories/src/plug.js
+++ b/test/npm-directories/src/plug.js
@@ -1,0 +1,3 @@
+exports.translate = function(load){
+	return load.source;
+};

--- a/test/test.js
+++ b/test/test.js
@@ -2254,6 +2254,24 @@ describe("npm package.json builds", function(){
 
 });
 
+describe("npm with directories.lib", function(){
+	beforeEach(function(done){
+		asap(rmdir)(__dirname + "/npm-directories/dist").then(function(){
+			done();
+		}, done);
+	});
+
+	it("builds and works", function(done){
+		multiBuild({
+			config: __dirname + "/npm-directories/package.json!npm"
+		}, {
+			quiet: true
+		}).then(function(){
+			done();
+		});
+	});
+});
+
 describe("Source Maps", function(){
 	describe("multi build", function(){
 		it("basics works", function(done){


### PR DESCRIPTION
Because the module name for a main will be something like:

```
package@1.0.0#module/path
```

You will need to load this in production with a script tag like:

```html
<script src="steal.production.js"
  main="package/module/path"></script>
```

And therefore the bundle name should be `bundles/package/module/path`.

Fixes #284