### PR TITLE
live-reload: receive initial module

### DIFF
--- a/lib/graph/recycle.js
+++ b/lib/graph/recycle.js
@@ -17,6 +17,11 @@ module.exports = function(config){
 	// be reused.
 	function regenerate(moduleName, done){
 		var cfg = clone(config, true);
+		// if the moduleName is not in the graph, make it the main.
+		if(moduleName && !cachedData.graph[moduleName]) {
+			cfg.main = moduleName;
+		}
+
 		makeBundleGraph(cfg).then(function(data){
 			var graph = data.graph;
 			var oldGraph = cachedData.graph;
@@ -70,7 +75,9 @@ module.exports = function(config){
 					next(err);
 				});
 			} else {
-				regenerate(null, next);
+				// Either load the module name, which is not part of the graph
+				// or will pass null thus reloading the main graph.
+				regenerate(moduleName || null, next);
 			}
 		}
 	}

--- a/lib/stream/live.js
+++ b/lib/stream/live.js
@@ -22,6 +22,14 @@ module.exports = function(config, options){
 	var wss = createServer(options);
 	var port = wss.options.server.address().port;
 
+	wss.on("connection", function(ws){
+		// Get the initial graph for this main,
+		// if it's not already part of the graph.
+		ws.once("message", function(moduleName){
+			graphStream.write(moduleName);
+		});
+	});
+
 	var watchStream = watch(graphStream);
 	watchStream.on("data", onChange);
 


### PR DESCRIPTION
This updates live-reload to receive the initial module (the loader.main) when it first starts up. This is so that if you load a test page, or a demo page, or any page where the main is different from the application main, the server will be aware of the graph and live-reload will work.