### PR TITLE
Update env set during the build

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "steal-tools",
   "version": "0.11.0-pre.10",
   "devDependencies": {
-    "steal": "^0.11.0-pre.1",
+    "steal": "^0.11.0-pre.8",
     "jquery": "~1.10.0",
     "less" : "^2.4.0"
   }

--- a/lib/graph/make_graph.js
+++ b/lib/graph/make_graph.js
@@ -23,7 +23,7 @@ module.exports = function(config, options){
 	var localSteal = steal.clone();
 	addParseAMD( localSteal.System );
 
-	localSteal.System.config({ env: "development,build" });
+	localSteal.System.config({ env: "build-development" });
 	localSteal.System.config(config);
 	localSteal.System.systemName = (localSteal.System.systemName||"")+"-local";
 	// This version of steal, and it's System can be used to load

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "moment": "^2.10.2",
     "pdenodeify": "^0.1.0",
     "source-map": "git://github.com/bitovi/source-map#0.4.2-bitovi.1",
-    "steal": "^0.11.0-pre.1",
+    "steal": "^0.11.0-pre.8",
     "steal-bundler": "^0.2.0",
     "system-parse-amd": "0.0.2",
     "through2": "^2.0.0",


### PR DESCRIPTION
Now during the build we will be setting the env to `build-development` rather than the comma-separated form we had used in the previous iteration of envs config. Closes #295 