### PR TITLE
LocalSteal should be in the development environment

### DIFF
--- a/lib/graph/make_graph.js
+++ b/lib/graph/make_graph.js
@@ -23,7 +23,7 @@ module.exports = function(config, options){
 	var localSteal = steal.clone();
 	addParseAMD( localSteal.System );
 
-	localSteal.System.config({ env: "build-development" });
+	localSteal.System.config({ env: "development" });
 	localSteal.System.config(config);
 	localSteal.System.systemName = (localSteal.System.systemName||"")+"-local";
 	// This version of steal, and it's System can be used to load


### PR DESCRIPTION
So it correctly loads the entire dependency graph.