### PR TITLE
Use new system-trace extension

### DIFF
--- a/lib/graph/make_graph.js
+++ b/lib/graph/make_graph.js
@@ -67,35 +67,26 @@ module.exports = function(config, options){
 
 	// Setup trace to callback when a module is found.
 
-	trace(localSteal.System, buildSteal.System, function(load, deps, pluginValue){
+	trace(localSteal.System, buildSteal.System, function(load, deps, dependencies, pluginValue){
 		if(formatMap[load.metadata.format]) {
 			load.metadata.format= formatMap[load.metadata.format];
 		}
 
 		winston.debug( (localSteal.System.systemName||"") +'+ ' + load.name+ (
-			localSteal.System.bundle ? "-"+localSteal.System.bundle : ""));
+		localSteal.System.bundle ? "-"+localSteal.System.bundle : ""));
 		// there could have been an old load from the BuildSystem
 		var oldLoad = graph[load.name];
 
 		var loadNode = graph[load.name] = {};
 		loadNode.load = load;
-
 		loadNode.deps = deps;
+		loadNode.dependencies = dependencies;
 
-		if(arguments.length === 3){
+		if(arguments.length === 4){
 			// only mark as plugin if there was an oldLoad
 			loadNode.isPlugin = !oldLoad;
 			loadNode.value = pluginValue;
 		}
-
-		var depPromise = Promise.all(deps.map(function(dep){
-			return Promise.resolve( localSteal.System.normalize(dep, load.name, load.address) );
-		})).then(function(dependencies){
-			loadNode.dependencies = dependencies;
-		}, function(err){
-			winston.warn("unable to resolve dependency ", err);
-		});
-		depPromises.push(depPromise);
 	});
 
 	return buildPromise.then(function(){

--- a/lib/graph/pluck.js
+++ b/lib/graph/pluck.js
@@ -4,13 +4,13 @@ var winston = require('winston');
 module.exports = function(graph, name){
 	var modules = [];
 	var visited = {};
-	
+
 	function visit( name ) {
 		if(!visited[name]) {
-		
+
 			visited[name] = true;
 			var node = graph[name];
-		
+
 			delete graph[name];
 			if(!node) {
 				winston.warn("Can't find dependency",name,"in graph.");

--- a/lib/graph/transpile.js
+++ b/lib/graph/transpile.js
@@ -26,7 +26,7 @@ var key = function(options,format) {
 
 var transpileNode = function(node, outputFormat, options, graph, loader){
 	var name = node.load.name;
-	
+
 	if( !node.load.metadata.buildType || node.load.metadata.buildType === "js"  ) {
 
 		// Nodes can provide their own `translate` function as part of metadata.
@@ -38,12 +38,12 @@ var transpileNode = function(node, outputFormat, options, graph, loader){
 				};
 			});
 		}
-		
+
 		transformActiveSource(node,key(options, outputFormat),function(node, source){
 
 			var opts = _.clone(options);
 			var depMap = nodeDependencyMap(node);
-			
+
 			if(opts.useNormalizedDependencies) {
 				opts.normalizeMap = depMap;
 			}
@@ -69,7 +69,7 @@ var transpileNode = function(node, outputFormat, options, graph, loader){
 				opts.baseURL = opts.sourceMapPath;
 			}
 			if(opts.normalize) {
-				
+
 				var givenNormalize = opts.normalize;
 				opts.normalize = function(name, curName){
 					// if name === curName ... it's asking to normalize the current module's name
@@ -95,7 +95,7 @@ var transpileNode = function(node, outputFormat, options, graph, loader){
 
 // fullGraph - if graph is a bundle ... fullGraph is the actual graph
 module.exports = function(graph, outputFormat, options, data){
-	
+
 	options = options || {};
 	if(Array.isArray(graph)) {
 		graph.forEach(function(node){

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -1,4 +1,3 @@
-var getESModuleImports = require("./load/get_es_module_imports");
 var nodeRequire = require;
 
 
@@ -68,10 +67,6 @@ var trace = function(System, BuildSystem, onFulfilled){
 
 			return instantiateResult;
 		});
-	};
-
-	var emptyExecute = function(){
-		return new System.newModule({});
 	};
 };
 

--- a/lib/trace.js
+++ b/lib/trace.js
@@ -1,4 +1,5 @@
 var getESModuleImports = require("./load/get_es_module_imports");
+var nodeRequire = require;
 
 
 var trace = function(System, BuildSystem, onFulfilled){
@@ -6,40 +7,56 @@ var trace = function(System, BuildSystem, onFulfilled){
 	System.pluginLoader = BuildSystem;
 	BuildSystem.localLoader = System;
 
+	//System.preventModuleExecution = true;
+
 	// The BuildSystem loader will execute modules, but wait for the value to come through
 	var buildInstantiate = BuildSystem.instantiate;
 	BuildSystem.instantiate = function(load){
 
-		var res = buildInstantiate.apply(this, arguments),
-			deps;
-
-		// Get the deps
-		Promise.resolve(res).then(function(instantiateResult){
-			if(!instantiateResult) {
-				deps = getESModuleImports(load);
-			} else {
-				deps = instantiateResult.deps ? instantiateResult.deps.slice(0) : [];
-			}
-		});
+		var res = buildInstantiate.apply(this, arguments);
 
 		// Get the value of the plugin (this will let us check for includeInBuild)
 		BuildSystem.import(load.name).then(function(pluginValue){
-			onFulfilled(load, deps, pluginValue);
+			//var deps = BuildSystem._traceData.deps[load.name];
+			//var dependencies = BuildSystem.getDependencies(load.name);
+			var deps = load.metadata.deps || [];
+			var dependencies = load.metadata.dependencies || [];
+			onFulfilled(load, deps, dependencies, pluginValue);
 		});
 
 		return res;
 
 	};
 
-	// O
+	System.preventModuleExecution = true;
+	System.allowModuleExecution(System.configMain);
+
+	// Override instantiate
 	var systemInstantiate = System.instantiate;
 	System.instantiate = function(load){
 		// Figure out if there's a plugin
 		var pluginName = load.metadata.pluginName;
 
+		if(load.name === "babel") {
+			return {
+				deps: [],
+				execute: function(){
+					var value = nodeRequire("babel");
+					return System.newModule(value);
+				}
+			};
+		}
+
 		var res = systemInstantiate.apply(this, arguments);
 
 		return Promise.resolve(res).then(function fullfill(instantiateResult){
+			var deps = load.metadata.deps || [];
+			var dependencies = load.metadata.dependencies || [];
+			if(pluginName) {
+				deps = deps.concat([pluginName]);
+				dependencies = dependencies.concat([pluginName]);
+			}
+
 			// If the config is a global mark it as cjs so that it will be converted
 			// to AMD by transpile. Needed because of this bug:
 			// https://github.com/ModuleLoader/es6-module-loader/issues/231
@@ -47,31 +64,9 @@ var trace = function(System, BuildSystem, onFulfilled){
 				load.metadata.format = "cjs";
 			}
 
-			if(!instantiateResult) {
-				var imports = getESModuleImports(load);
-				onFulfilled(load, pluginName ? imports.concat(pluginName) : imports.slice(0) );
+			onFulfilled(load, deps, dependencies);
 
-				if(load.name === System.configMain) {
-					return;
-				} else {
-					return {
-						deps: imports,
-						execute: emptyExecute
-					};
-				}
-			} else {
-				onFulfilled(load, pluginName ? instantiateResult.deps.concat(pluginName) : instantiateResult.deps.slice(0) );
-
-				if(load.name === System.configMain) {
-					return instantiateResult;
-				} else {
-					return {
-							deps: instantiateResult.deps,
-							execute: emptyExecute
-						};
-					}
-				}
-
+			return instantiateResult;
 		});
 	};
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "moment": "^2.10.2",
     "pdenodeify": "^0.1.0",
     "source-map": "git://github.com/bitovi/source-map#0.4.2-bitovi.1",
-    "steal": "git://github.com/stealjs/steal#minor",
+    "steal": "^0.12.0-pre.0",
     "steal-bundler": "^0.2.0",
     "system-parse-amd": "0.0.2",
     "through2": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "moment": "^2.10.2",
     "pdenodeify": "^0.1.0",
     "source-map": "git://github.com/bitovi/source-map#0.4.2-bitovi.1",
-    "steal": "git://github.com/stealjs/steal#trace",
+    "steal": "git://github.com/stealjs/steal#minor",
     "steal-bundler": "^0.2.0",
     "system-parse-amd": "0.0.2",
     "through2": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "web": "http://bitovi.com/"
   },
   "dependencies": {
+    "babel": "^5.8.23",
     "chokidar": "^1.0.1",
     "clean-css": "3.1.8",
     "colors": "^0.6.2",
@@ -19,7 +20,7 @@
     "moment": "^2.10.2",
     "pdenodeify": "^0.1.0",
     "source-map": "git://github.com/bitovi/source-map#0.4.2-bitovi.1",
-    "steal": "^0.11.0",
+    "steal": "git://github.com/stealjs/steal#trace",
     "steal-bundler": "^0.2.0",
     "system-parse-amd": "0.0.2",
     "through2": "^2.0.0",
@@ -94,8 +95,8 @@
   "scripts": {
     "test": "grunt test && grunt test:browser",
     "mocha": "grunt simplemocha",
-	"bower-install": "bower install",
-	"install-engine-dependencies": "install-engine-dependencies"
+    "bower-install": "bower install",
+    "install-engine-dependencies": "install-engine-dependencies"
   },
   "engines": {
     "node": "0.10.x - 0.12.x || ^3.0.0"


### PR DESCRIPTION
This upgrades `make_graph` to be based on the new system-trace extension that is comming in Steal 0.12.0.