### PR TITLE
Don't warn about missing pseudo-modules

### DIFF
--- a/lib/graph/pluck.js
+++ b/lib/graph/pluck.js
@@ -13,7 +13,9 @@ module.exports = function(graph, name){
 
 			delete graph[name];
 			if(!node) {
-				winston.warn("Can't find dependency",name,"in graph.");
+				if(name && name[0] !== "@") {
+					winston.warn("Can't find dependency",name,"in graph.");
+				}
 				return;
 			}
 			node.dependencies.forEach(function( moduleName ) {


### PR DESCRIPTION
Whenever you have a dependency using `@loader` or `@steal` it would warn that the dependency is missing from the dependency graph. Since these are pseudo-modules created in memory, they don't need to be part of the graph. So no need to warn about them.