### PR TITLE
Set localSteal environment to build-development with live-reload

### DIFF
--- a/lib/stream/live.js
+++ b/lib/stream/live.js
@@ -6,11 +6,15 @@ var defaults = require("lodash").defaults;
 var logging = require("../logger");
 
 module.exports = function(config, options){
+	if(!options) options = {};
 	defaults(options, { quiet: true });
 	logging.setup(options, config);
+	options.localStealConfig = {
+		env: "build-development"
+	};
 
 	// Create an initial dependency graph for this config.
-	var initialGraphStream = createBundleGraphStream(config);
+	var initialGraphStream = createBundleGraphStream(config, options);
 	// Create a stream that is used to regenerate a new graph on file changes.
 	var graphStream = recycle(config);
 

--- a/test/live_reload/foo.js
+++ b/test/live_reload/foo.js
@@ -1,0 +1,1 @@
+module.exports = 'bar';

--- a/test/live_reload/main.js
+++ b/test/live_reload/main.js
@@ -1,0 +1,5 @@
+var foo = require("./foo");
+
+window.MODULE = {
+	foo: foo
+};

--- a/test/live_reload/package.json
+++ b/test/live_reload/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "live-app",
+	"main": "main",
+	"version": "1.0.0",
+	"system": {
+		"configDependencies": [
+			"live-reload"
+		]
+	}
+}

--- a/test/test.js
+++ b/test/test.js
@@ -31,6 +31,12 @@ System.logLevel = 3;
 require("./test_cli");
 require("./grunt_tasks/steal_build");
 
+// Node 0.10 doesn't support Symbols so the live-reload tests will
+// not pass on it.
+if(typeof Symbol !== "undefined") {
+	require("./test_live");
+}
+
 (function(){
 
 

--- a/test/test_live.js
+++ b/test/test_live.js
@@ -1,0 +1,47 @@
+var assert = require("assert");
+var live = require("../lib/stream/live");
+var fs = require("fs");
+var asap = require("pdenodeify");
+
+describe("live-reload", function(){
+	this.timeout(10000);
+
+	var fooPath = __dirname + "/live_reload/foo.js";
+
+	beforeEach(function(done){
+		var self = this;
+		asap(fs.readFile)(fooPath, "utf8").then(function(content){
+			self._fooModule = content;
+		}).then(done, done);
+	});
+
+	afterEach(function(done){
+		asap(fs.writeFile)(fooPath, this._fooModule, "utf8").then(function(){
+			done();
+		}, done);
+	});
+
+	it("Starts a web socket server", function(done){
+		var liveStream = live({
+			config: __dirname + "/live_reload/package.json!npm"
+		}, {});
+
+		liveStream.once("data", function(data){
+			assert(/bar/.test(data.graph.foo.load.source),
+				   "Initial source contains 'bar'");
+
+			var newSource = "module.exports = 'foo';";
+			asap(fs.writeFile)(fooPath, newSource, "utf8").then(function(){
+				liveStream.once("data", function(data){
+					assert(/foo/.test(data.graph.foo.load.source),
+						   "New source contains 'foo'");
+					done();
+				});
+			});
+		});
+		liveStream.on("error", function(err){
+			done(err);
+		});
+	});
+
+});


### PR DESCRIPTION
This adds a test for live-reload and sets the localSteal environment to `build-development`. This is needed for live-reload to know not to set up a WebSocket connection.