### PR TITLE
Fixes race condition in live-reload server initialization.

### DIFF
--- a/lib/graph/recycle.js
+++ b/lib/graph/recycle.js
@@ -10,7 +10,7 @@ var removeActiveSourceKeys = require("./remove_active_source_keys");
  * @description Consumes a Dependency Graph and can regenerate another when
  * modules change.
  */
-module.exports = function(config){
+module.exports = function(config, options){
 	var cachedData;
 
 	// Regenerate a new bundle graph and copy over the transforms so they can
@@ -22,7 +22,7 @@ module.exports = function(config){
 			cfg.main = moduleName;
 		}
 
-		makeBundleGraph(cfg).then(function(data){
+		makeBundleGraph(cfg, options).then(function(data){
 			var graph = data.graph;
 			var oldGraph = cachedData.graph;
 			for(var name in graph){
@@ -56,6 +56,11 @@ module.exports = function(config){
 			next(null, data);
 		} else {
 			var moduleName = data;
+			// Reload happened before the graph was loaded.
+			if(!cachedData) {
+				next(null, {});
+				return;
+			}
 
 			// Get the old node and check to see if it has any new dependencies,
 			// if so just regenerate the entire graph.

--- a/lib/stream/live.js
+++ b/lib/stream/live.js
@@ -4,6 +4,7 @@ var recycle = require("../graph/recycle");
 var createServer = require("../create_websocket_server");
 var defaults = require("lodash").defaults;
 var logging = require("../logger");
+var toPromise = require("./to_promise");
 
 module.exports = function(config, options){
 	if(!options) options = {};
@@ -17,6 +18,7 @@ module.exports = function(config, options){
 	var initialGraphStream = createBundleGraphStream(config, options);
 	// Create a stream that is used to regenerate a new graph on file changes.
 	var graphStream = recycle(config, options);
+	var graphPromise = toPromise(graphStream);
 
 	// Pipe the graph stream into the recycleStream so it can get the initial
 	// graph.
@@ -30,7 +32,9 @@ module.exports = function(config, options){
 		// Get the initial graph for this main,
 		// if it's not already part of the graph.
 		ws.once("message", function(moduleName){
-			graphStream.write(moduleName);
+			graphPromise.then(function(){
+				graphStream.write(moduleName);
+			});
 		});
 	});
 

--- a/lib/stream/live.js
+++ b/lib/stream/live.js
@@ -16,7 +16,7 @@ module.exports = function(config, options){
 	// Create an initial dependency graph for this config.
 	var initialGraphStream = createBundleGraphStream(config, options);
 	// Create a stream that is used to regenerate a new graph on file changes.
-	var graphStream = recycle(config);
+	var graphStream = recycle(config, options);
 
 	// Pipe the graph stream into the recycleStream so it can get the initial
 	// graph.

--- a/lib/stream/to_promise.js
+++ b/lib/stream/to_promise.js
@@ -1,0 +1,8 @@
+
+module.exports = function(stream, event){
+	event = event || "data";
+
+	return new Promise(function(resolve){
+		stream.once(event, resolve);
+	});
+};

--- a/test/test_live.js
+++ b/test/test_live.js
@@ -2,23 +2,24 @@ var assert = require("assert");
 var live = require("../lib/stream/live");
 var fs = require("fs");
 var asap = require("pdenodeify");
+var WebSocket = require("ws");
 
 describe("live-reload", function(){
 	this.timeout(10000);
 
 	var fooPath = __dirname + "/live_reload/foo.js";
 
-	beforeEach(function(done){
+	before(function(done){
 		var self = this;
 		asap(fs.readFile)(fooPath, "utf8").then(function(content){
 			self._fooModule = content;
 		}).then(done, done);
 	});
 
-	afterEach(function(done){
+	after(function(done){
 		asap(fs.writeFile)(fooPath, this._fooModule, "utf8").then(function(){
 			done();
-		}, done);
+		});
 	});
 
 	it("Starts a web socket server", function(done){
@@ -26,16 +27,24 @@ describe("live-reload", function(){
 			config: __dirname + "/live_reload/package.json!npm"
 		}, {});
 
-		liveStream.once("data", function(data){
-			assert(/bar/.test(data.graph.foo.load.source),
-				   "Initial source contains 'bar'");
+		var ws = new WebSocket("ws://localhost:8012");
 
-			var newSource = "module.exports = 'foo';";
-			asap(fs.writeFile)(fooPath, newSource, "utf8").then(function(){
-				liveStream.once("data", function(data){
-					assert(/foo/.test(data.graph.foo.load.source),
-						   "New source contains 'foo'");
-					done();
+		ws.on("open", function(){
+			ws.send("main");
+		});
+
+		liveStream.once("data", function(data){
+			liveStream.once("data", function(data){
+				assert(/bar/.test(data.graph.foo.load.source),
+					   "Initial source contains 'bar'");
+
+				var newSource = "module.exports = 'foo';";
+				asap(fs.writeFile)(fooPath, newSource, "utf8").then(function(){
+					liveStream.once("data", function(data){
+						assert(/foo/.test(data.graph.foo.load.source),
+							"New source contains 'foo'");
+						done();
+					});
 				});
 			});
 		});
@@ -43,5 +52,4 @@ describe("live-reload", function(){
 			done(err);
 		});
 	});
-
 });


### PR DESCRIPTION

This is related to donejs/donejs#94

When can-serve and steal-tools live-reload are started at the same time with `donejs develop` it causes a race condition where if can-server loads before live-reload it will send a ping to the live-reload server to load the `System.main` into the stream. However it is possible that the graph hasn't been loaded by live-reload at this point, and if so an error will occur. The fix is to create a Promise out of the `graphStream` so that we don't write into it until it has been initiated.