### PR TITLE
Detect changes to dynamic bundles in graph/recycle

### DIFF
--- a/lib/graph/recycle.js
+++ b/lib/graph/recycle.js
@@ -66,9 +66,13 @@ module.exports = function(config, options){
 			// if so just regenerate the entire graph.
 			var node = cachedData.graph[moduleName];
 			if(node) {
+				var oldBundle = (cachedData.loader.bundle || []).slice();
 				getDependencies(node.load).then(function(result){
+					var newBundle = (cachedData.loader.bundle || []).slice();
+
 					// If the deps are the same we can return the existing graph.
-					if(same(node.deps, result.deps)) {
+					if(same(node.deps, result.deps) &&
+					   same(oldBundle, newBundle)) {
 						clean(node, result.source);
 						removeActiveSourceKeys(cachedData.graph);
 						cachedData = cloneData(cachedData);

--- a/test/recycle_dynamic/another.js
+++ b/test/recycle_dynamic/another.js
@@ -1,0 +1,3 @@
+var dep = require("./dep");
+
+module.exports = "another";

--- a/test/recycle_dynamic/config.js
+++ b/test/recycle_dynamic/config.js
@@ -1,0 +1,1 @@
+System.config({});

--- a/test/recycle_dynamic/dep.js
+++ b/test/recycle_dynamic/dep.js
@@ -1,0 +1,1 @@
+module.exports = "dep";

--- a/test/recycle_dynamic/plug.js
+++ b/test/recycle_dynamic/plug.js
@@ -1,0 +1,18 @@
+var loader = require("@loader");
+
+exports.translate = function(load){
+	// Detect dynamic imports
+	var res = /System\.import\("([a-z]+)"\)/.exec(load.source);
+	if(res) {
+		var localLoader = loader.localLoader || loader;
+		var bundle = localLoader.bundle;
+		if(!bundle) {
+			bundle = localLoader.bundle = [];
+		}
+		bundle.push(res[1]);
+	}
+
+	return "def" + "ine([], function(){" +
+
+	"});";
+};

--- a/test/recycle_dynamic/something.txt
+++ b/test/recycle_dynamic/something.txt
@@ -1,0 +1,1 @@
+this is some text

--- a/test/test.js
+++ b/test/test.js
@@ -253,6 +253,51 @@ if(!isIOjs) {
 			depStream.write(config.main);
 
 		});
+
+		it("Detects dynamic imports added when no static dependencies have changed", function(done){
+			var config = {
+				config: path.join(__dirname, "/recycle_dynamic/config.js"),
+				main: "something.txt!plug",
+				logLevel: 3,
+				map: { "@dev": "@empty" }
+			};
+
+			var depStream = bundle.createBundleGraphStream(config);
+			var recycleStream = recycle(config);
+
+			depStream.pipe(recycleStream);
+
+			// Wait for it to initially finish loading.
+			recycleStream.once("data", function(data){
+				var node = data.graph["something.txt!plug"];
+
+				// Update the module so that it has a dynamic import. This should
+				// be added to the loader's bundle and the graph reloaded.
+				var mockOptions = {};
+				Object.keys(data.graph).forEach(function(moduleName){
+					var load = data.graph[moduleName].load;
+					mockOptions[load.address.replace("file:", "")] = load.source;
+				});
+				mockOptions[node.load.address.replace("file:", "")] =
+					'System.import("another");';
+				mockOptions[path.resolve(__dirname + "/recycle_dynamic/another.js")]
+					= 'var dep = require("./dep");';
+				mockOptions[path.resolve(__dirname + "/recycle_dynamic/dep.js")]
+					= 'module.exports = "dep";';
+				mockFs(mockOptions);
+
+				recycleStream.write(node.load.name);
+				recycleStream.once("data", function(data){
+					var graph = data.graph;
+					assert(graph["another"], "this bundle was added to the graph");
+					assert(graph["dep"], "the bundle's dependency was also added");
+					done();
+				});
+			});
+
+			depStream.write(config.main);
+
+		});
 	});
 }
 


### PR DESCRIPTION
The done-autorender plugin and the can/view/stache/system plugin will both detect dynamic imports and add those to the `bundle` array on the loader. When recycling a module (such as in live-reload) we have an optimization that only reloads the dependency graph when there have been changes to the module's static dependencies. We need to compare the `bundle` array as well, and if that has changed also reload the dependency graph. Fixes #313