### PR TITLE
fixing IE8 "Expected identifier" Error when injecting import statement

### DIFF
--- a/lib/bundle/add_steal.js
+++ b/lib/bundle/add_steal.js
@@ -10,7 +10,7 @@ module.exports = function(bundle, main, configuration){
 		makeStealNode(configuration),
 		makeDefineNode()
 	);
-	bundle.nodes.push( makeNode("[import-main-module]", "System.import('"+configuration.configMain+"').then(function() {\nSystem.import('"+main+"'); \n});") );
+	bundle.nodes.push( makeNode("[import-main-module]", "System[\"import\"]('"+configuration.configMain+"').then(function() {\nSystem[\"import\"]('"+main+"'); \n});") );
 };
 
 function makeProductionConfigNode(configuration){


### PR DESCRIPTION
Hi Mathew, 

Just doing some testing in IE and found dot notation in add_steal. So I updated the dot notation to use square bracket notation, otherwise IE8 complains about Expected identifier.
![screen shot 2015-10-02 at 4 23 10 pm](https://cloud.githubusercontent.com/assets/7566382/10259840/f9463d20-6921-11e5-90a8-04f65f2fab99.png)
