### PR TITLE
adding test for traceurOptions

### DIFF
--- a/lib/graph/transpile.js
+++ b/lib/graph/transpile.js
@@ -53,6 +53,9 @@ var transpileNode = function(node, outputFormat, options, graph, loader){
 			if(loader.babelOptions) {
 				opts.babelOptions = loader.babelOptions;
 			}
+			if(loader.traceurOptions) {
+				opts.traceurOptions = loader.traceurOptions;
+			}
 			// make sure load has activeSource
 			var load = _.clone(node.load, true);
 			load.source = source.code || load.source;

--- a/test/test.js
+++ b/test/test.js
@@ -412,13 +412,13 @@ describe("multi build", function(){
 			multiBuild({
 				config: __dirname + "/es6-loose/config.js",
 				main: "main",
-				transpiler: "babel"
-			}, {
-				quiet: true,
-				minify: false,
+				transpiler: "babel",
 				babelOptions: {
 					loose: 'es6.modules'
 				}
+			}, {
+				quiet: true,
+				minify: false
 			}).then(function(){
 				fs.readFile("test/es6-loose/dist/bundles/main.js", "utf8", function(err, data) {
 					if (err) {
@@ -446,12 +446,12 @@ describe("multi build", function(){
 			multiBuild({
 				config: __dirname + "/es6-loose/config.js",
 				main: "main",
-			}, {
-				quiet: true,
-				minify: false,
 				traceurOptions: {
 					properTailCalls: true
 				}
+			}, {
+				quiet: true,
+				minify: false
 			}).then(function(){
 				fs.readFile("test/es6-loose/dist/bundles/main.js", "utf8", function(err, data) {
 					if (err) {

--- a/test/test.js
+++ b/test/test.js
@@ -436,6 +436,37 @@ describe("multi build", function(){
 		});
 	});
 
+	it("should pass the traceurOptions to transpile", function(done){
+		console.log('starting test');
+		rmdir(__dirname + "/es6-loose/bundle", function(error){
+			if(error) {
+				return done(error);
+			}
+
+			multiBuild({
+				config: __dirname + "/es6-loose/config.js",
+				main: "main",
+			}, {
+				quiet: true,
+				minify: false,
+				traceurOptions: {
+					properTailCalls: true
+				}
+			}).then(function(){
+				fs.readFile("test/es6-loose/dist/bundles/main.js", "utf8", function(err, data) {
+					if (err) {
+						done(err);
+					}
+
+					var noObjectDefineProperty = data.indexOf("Object.defineProperty") > 0;
+
+					assert(noObjectDefineProperty, "properTailCalls option should use Object.defineProperty");
+					done();
+				});
+			}).catch(done);
+		});
+	});
+
 	it("doesn't include the traceur runtime if it's not being used", function(done){
 		rmdir(__dirname + "/simple-es6/dist", function(error){
 			if(error) {


### PR DESCRIPTION
Test for `traceurOptions` to support https://github.com/stealjs/steal-tools/issues/319 which is handled by https://github.com/stealjs/transpile/pull/45.