### PR TITLE
Upgrading ws to 0.8.0 to fix node 4.x install errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "uglify-js": "~2.4.13",
     "urix": "^0.1.0",
     "winston": "^0.7.3",
-    "ws": "^0.7.1",
+    "ws": "^0.8.0",
     "yargs": "^1.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes the install error when Using node 4.x. The new version of the `ws` package has updated its dependencies to work with a newer version of nan.