### PR TITLE
Properly report transpile errors

### DIFF
--- a/lib/graph/transpile.js
+++ b/lib/graph/transpile.js
@@ -91,7 +91,14 @@ var transpileNode = function(node, outputFormat, options, graph, loader){
 					return givenNormalize.call(this, name, depLoad, curName, load, loader);
 				};
 			}
-			return transpile.to(load, outputFormat, opts);
+			try {
+				return transpile.to(load, outputFormat, opts);
+			} catch(err) {
+				var message = "Unable to transpile " + load.name + ": \n\n" +
+					err.message;
+				err.message = message;
+				throw err;
+			}
 		});
 	}
 };

--- a/lib/stream/build.js
+++ b/lib/stream/build.js
@@ -109,8 +109,12 @@ module.exports = function(config, options){
 	var minify = options.minify = options.minify !== false;
 
 	return through.obj(function(data, enc, done){
-		var buildResult = multiBuild(data);
-		done(null, buildResult);
+		try {
+			var buildResult = multiBuild(data);
+			done(null, buildResult);
+		} catch(err) {
+			done(err);
+		}
 	});
 
 	function multiBuild(data){

--- a/test/test.js
+++ b/test/test.js
@@ -1401,6 +1401,22 @@ describe("multi build with plugins", function(){
 		});
 	});
 
+	it("Errors that happen during transpile are reported with the name of the module that failed", function(done){
+
+		multiBuild({
+			config: __dirname + "/stealconfig.js",
+			main: "transpile_error/main"
+		}, {
+			minify: false,
+			quiet: true
+		}).then(function(){
+			assert(false, "Succeeded when it should not have");
+		}, function(err){
+			assert(/Unable to transpile transpile_error\/main:/.test(err.message),
+				   "Reports the module that had the transpile error");
+		}).then(done, done);
+	});
+
 });
 
 

--- a/test/transpile_error/main.js
+++ b/test/transpile_error/main.js
@@ -1,0 +1,4 @@
+"format cjs";
+
+// Cause an unexpected token exception
+consolelog(|blah|)


### PR DESCRIPTION
This improves the reporting of transpile errors by including the name of the module that failed to transpile at the top of the error message. Closes #328