### PR TITLE
Conditionally set bundles/* paths only if not using bundlesPath

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,4 @@
 end_of_line = LF
 indent_style = tab
 indent_size = 4
+trim_trailing_whitespace = false

--- a/lib/bundle/make_bundles_config.js
+++ b/lib/bundle/make_bundles_config.js
@@ -1,7 +1,7 @@
 var util = require("util");
 
 /**
- * 
+ *
  * @param {Object} bundles
  * @param {Object} configuration
  * @param {Object} targetBundle the bundle this config is being built for.
@@ -10,12 +10,12 @@ var util = require("util");
 module.exports = function(bundles, configuration, targetBundle, options){
 	var paths = getBundlesPaths(configuration);
 	var excludedBundles = options.excludedBundles || {};
-	
+
 	var bundledBundles = bundles.slice(0);
 	if(configuration.options.bundleSteal){
 		bundledBundles.shift();
 	}
-	
+
 	var bundlesConfig = {};
 	bundledBundles.forEach(function(bundle){
 		// Don't write a bundles config for your own bundle.  Otherwise,
@@ -26,7 +26,7 @@ module.exports = function(bundles, configuration, targetBundle, options){
 			});
 		}
 	});
-	
+
 	return {
 		load: {name: "[system-bundles-config]"},
 		minifiedSource: paths + "System.bundles = "+JSON.stringify(bundlesConfig)+";"
@@ -43,9 +43,9 @@ function getBundlesPaths(configuration){
 	var bundlesPath = configuration.bundlesPathURL;
 
 	// Get the dist directory and set the paths output
-	var paths = util.format('System.paths["bundles/*.css"] ="%s/*css";\n' +
-													'System.paths["bundles/*"] = "%s/*.js";\n',
+	var paths = util.format('\tSystem.paths["bundles/*.css"] ="%s/*css";\n' +
+													'\tSystem.paths["bundles/*"] = "%s/*.js";\n',
 													bundlesPath, bundlesPath);
 	// TODO: we should probably give a warning to make sure you include this in your production html's configuration.
-	return paths;
+	return "if(!System.bundlesPath) {\n" + paths + "}\n";
 }

--- a/test/bundle_path/main.js
+++ b/test/bundle_path/main.js
@@ -1,0 +1,16 @@
+require("./style.css!");
+
+function getFile(url, cb) {
+	var xhr = new XMLHttpRequest();
+	xhr.open("GET", url, true);
+	xhr.send(null);
+	xhr.onreadystatechange = function(){
+		if(xhr.readyState === 4) {
+			cb(xhr.responseText);
+		}
+	};
+}
+
+getFile(document.getElementsByTagName('link')[0].href, function(content){
+	window.STYLE_CONTENT =  content;
+});

--- a/test/bundle_path/style.css
+++ b/test/bundle_path/style.css
@@ -1,0 +1,8 @@
+body {
+	background: green;
+}
+
+#test-element {
+	width: 50px;
+	background-color: yellow;
+}

--- a/test/bundle_path/subfolder/index.html
+++ b/test/bundle_path/subfolder/index.html
@@ -1,0 +1,6 @@
+<div id="test-element">#test-element</div>
+<script src="../../../bower_components/steal/steal.js"
+	data-env="production"
+	data-config="./config.js"
+	data-main="main"
+	data-bundles-path="../javascript/dist"></script>

--- a/test/test.js
+++ b/test/test.js
@@ -647,6 +647,31 @@ describe("multi build", function(){
 
 	});
 
+	it("Works with bundlesPath and loading from a subfolder", function(done){
+		this.timeout(5000);
+
+		rmdir(__dirname + "/bundle_path/javascript/dist", function(error){
+			if(error) return done(error);
+
+			multiBuild({
+				config: __dirname + "/bundle_path/config.js",
+				main: "main",
+				bundlesPath: __dirname + "/bundle_path/javascript/dist"
+			}, {
+				minify: false,
+				quiet: true
+			}).then(function(){
+				open("test/bundle_path/subfolder/index.html",
+					 function(browser, close){
+					find(browser,"STYLE_CONTENT", function(styleContent){
+						assert(styleContent.indexOf("#test-element")>=0, "have correct style info");
+						close();
+					}, close);
+				}, done);
+			});
+		});
+	});
+
 
 	it("supports bundling steal", function(done){
 


### PR DESCRIPTION
If the user has set bundlesPath in the client then there is no need to set the `bundles/*` paths as those are being set in Steal. By overriding them it can cause the bundles to be loaded from the incorrect location.

Closes #334