### PR TITLE
Properly recycle virtual modules

### DIFF
--- a/lib/graph/recycle.js
+++ b/lib/graph/recycle.js
@@ -66,14 +66,8 @@ module.exports = function(config, options){
 			// if so just regenerate the entire graph.
 			var node = cachedData.graph[moduleName];
 			if(node) {
-				var oldBundle = (cachedData.loader.bundle || []).slice();
-				getDependencies(node.load).then(function(result){
-					var newBundle = (cachedData.loader.bundle || []).slice();
-
-					// If the deps are the same we can return the existing graph.
-					if(same(node.deps, result.deps) &&
-					   same(oldBundle, newBundle)) {
-						clean(node, result.source);
+				diff(node).then(function(result){
+					if(result.same) {
 						removeActiveSourceKeys(cachedData.graph);
 						cachedData = cloneData(cachedData);
 						return next(null, cachedData);
@@ -89,6 +83,45 @@ module.exports = function(config, options){
 				regenerate(moduleName || null, next);
 			}
 		}
+	}
+
+	/**
+	 * Check to see if the node has changed. Do this by looking at the source
+	 * and running it through System.instantiate to see if new deps were added.
+	 * Recursively do the same for any System.defined modules.
+	 */
+	function diff(node) {
+		var oldBundle = (cachedData.loader.bundle || []).slice();
+
+		return getDependencies(node.load).then(function(result){
+			var newBundle = (cachedData.loader.bundle || []).slice();
+
+			// If the deps are the same we can return the existing graph.
+			if(same(node.deps, result.deps) &&
+			   same(oldBundle, newBundle)) {
+				clean(node, result.source);
+
+				if(result.virtualModules.length) {
+					var promises = result.virtualModules.map(function(l){
+						var node = cachedData.graph[l.name];
+						node.load.source = l.source;
+						node.load.metadata.useSource = true;
+						return diff(node);
+					});
+
+					return Promise.all(promises).then(function(results){
+						result.same = results.every(function(res){
+							return res.same;
+						});
+						return result;
+					});
+				}
+
+				result.same = true;
+			}
+			return result;
+		});
+
 	}
 
 	return through.obj(cached);

--- a/lib/node_trace.js
+++ b/lib/node_trace.js
@@ -11,20 +11,30 @@ module.exports = function(load){
 
 	var localSteal = steal.clone();
 	var System = localSteal.System;
+	System.preventModuleExecution = true;
+	trap(System);
+
+	if(load.metadata.useSource) {
+		return compare(load.source);
+	}
 
 	var address = load.address.replace("file:", "");
-	return readFile(address, "utf8")
-		.then(function(source){
+	return readFile(address, "utf8").then(compare);
+
+	function compare(source){
+		return Promise.resolve().then(function(){
 			var plugin = load.metadata.plugin;
 			var translatePromise;
 			if(plugin && plugin.translate) {
 				load.source = source;
-				translatePromise = Promise.resolve(plugin.translate.call(System, load));
+				translatePromise = Promise.resolve(
+					plugin.translate.call(System, load));
 			} else {
 				translatePromise = Promise.resolve(source);
 			}
 			return translatePromise;
-		}).then(function(source){
+		})
+		.then(function(source){
 			if(source) {
 				load.source = source;
 			}
@@ -39,8 +49,26 @@ module.exports = function(load){
 					if(!~deps.indexOf(pluginDep)) deps.push(pluginDep);
 				}
 
-				return { source: load.source, deps: deps };
+				return {
+					source: load.source,
+					deps: deps,
+					virtualModules: System.virtualDefines
+				};
 			});
-
 		});
+	}
+
 };
+
+function trap(System) {
+	// trap defines so we know about them.
+	System.virtualDefines = [];
+	System.define = function(name, source){
+		this.virtualDefines.push({name:name,source:source});
+	};
+
+	// prevent fetch
+	System.fetch = function(){
+		return '';
+	};
+}

--- a/test/virtual_recycle/comp.js
+++ b/test/virtual_recycle/comp.js
@@ -1,0 +1,13 @@
+// This a weird plugin that takes the source from a module and defines
+// a new virtual module with that source, and then makes that virtual module
+// a dependency of the first.
+exports.translate = function(load){
+	var source = load.source;
+	var loader = this;
+
+	loader.define("foo", source);
+
+	return "def" + "ine(['foo'], function(foo){\n" +
+	"\treturn foo;\n" +
+	"});\n";
+};

--- a/test/virtual_recycle/dev.html
+++ b/test/virtual_recycle/dev.html
@@ -1,0 +1,3 @@
+<script src="../../bower_components/steal/steal.js"
+	config="./config.js"
+	main="main"></script>

--- a/test/virtual_recycle/main.js
+++ b/test/virtual_recycle/main.js
@@ -1,0 +1,3 @@
+var other = require("./other.txt!comp");
+
+console.log(other);

--- a/test/virtual_recycle/other.txt
+++ b/test/virtual_recycle/other.txt
@@ -1,0 +1,1 @@
+module.exports = 'other';


### PR DESCRIPTION
This fixes #341

This is a good fix because it doesn't require any special configuration by plugins. Instead we detect any virtual modules that are created with System.define. When we diff a module to see if it has added/removed dependencies we run it through System.translate and System.instantiate. If translate produces virtual modules we then run the same process on the virtual modules. If anything has changed at all we know that a full trace is needed to get a fresh graph.