### PR TITLE
Make fetch override return a Promise

### DIFF
--- a/lib/node_trace.js
+++ b/lib/node_trace.js
@@ -69,6 +69,6 @@ function trap(System) {
 
 	// prevent fetch
 	System.fetch = function(){
-		return '';
+		return Promise.resolve('');
 	};
 }


### PR DESCRIPTION
This is for the node_trace module that is used to find if dependendencies have changed in graph/recycle. We override fetch, but were not returning a Promise. Many extensions expect fetch to return a Promise.