### PR TITLE
Minify CSS before writing the bundles.

### DIFF
--- a/lib/bundle/minify_source.js
+++ b/lib/bundle/minify_source.js
@@ -1,0 +1,11 @@
+var minifyCSS = require("../buildTypes/minifyCSS");
+
+module.exports = function(bundle, options) {
+	options = options || {};
+
+	if (options.minify && bundle.buildType === "css") {
+		bundle.source = minifyCSS(bundle.source, options);
+	}
+
+	return bundle;
+};

--- a/lib/bundle/write_bundles.js
+++ b/lib/bundle/write_bundles.js
@@ -3,13 +3,14 @@
 // Writes them out to the file system.
 var bundleFilename = require("./filename"),
 	concatSource = require("../bundle/concat_source"),
-	normalizeSource = require('./normalize_source'),
+	normalizeSource = require("./normalize_source"),
 	fs = require("fs"),
 	mkdirp = require("fs-extra").mkdirp,
 	dirname = require("path").dirname,
 	addSourceMapUrl = require("../bundle/add_source_map_url"),
 	through = require("through2"),
-	winston = require('winston');
+	winston = require("winston"),
+	minifySource = require("./minify_source");
 
 var writeBundles = module.exports = function(bundles, configuration) {
 	var bundlesDir = configuration.bundlesPath + "/";
@@ -34,6 +35,9 @@ var writeBundles = module.exports = function(bundles, configuration) {
 
 			// Combines the source
 			concatSource(bundle);
+
+			// minify concatenated source
+			minifySource(bundle, configuration.options);
 
 			var code = bundle.source.code, map;
 			if(configuration.options.sourceMaps) {

--- a/lib/bundle/write_bundles.js
+++ b/lib/bundle/write_bundles.js
@@ -1,8 +1,6 @@
 // # lib/bundle/write_bundles.js
 // Given an array of bundles and the baseURL
 // Writes them out to the file system.
-
-var winston = require('winston');
 var bundleFilename = require("./filename"),
 	concatSource = require("../bundle/concat_source"),
 	normalizeSource = require('./normalize_source'),
@@ -10,81 +8,80 @@ var bundleFilename = require("./filename"),
 	mkdirp = require("fs-extra").mkdirp,
 	dirname = require("path").dirname,
 	addSourceMapUrl = require("../bundle/add_source_map_url"),
-	through = require("through2");
+	through = require("through2"),
+	winston = require('winston');
 
 var writeBundles = module.exports = function(bundles, configuration) {
-  var bundlesDir = configuration.bundlesPath + "/";
-  // Create the bundle directory
-  var bundleDirDef = configuration.mkBundlesPathDir();
+	var bundlesDir = configuration.bundlesPath + "/";
+	// Create the bundle directory
+	var bundleDirDef = configuration.mkBundlesPathDir();
 
-  // A deferred containing a deferred that resolves when all
-  // deferreds have been built.
-  var builtBundleDeferreds = [];
+	// A deferred containing a deferred that resolves when all
+	// deferreds have been built.
+	var builtBundleDeferreds = [];
 
-  bundles.forEach(function(bundle) {
-    builtBundleDeferreds.push(new Promise(function(resolve, reject) {
-      var bundlePath = bundlesDir + "" + bundleFilename(bundle);
+	bundles.forEach(function(bundle) {
+		builtBundleDeferreds.push(new Promise(function(resolve, reject) {
+			var bundlePath = bundlesDir + "" + bundleFilename(bundle);
 
-	  // If the bundle is explicity marked as clean, just resolve.
-	  if(bundle.isDirty === false) {
-		return resolve(bundle);
-	  }
+			// If the bundle is explicity marked as clean, just resolve.
+			if(bundle.isDirty === false) {
+				return resolve(bundle);
+			}
 
-      // Adjusts URLs
-      normalizeSource(bundle, bundlePath);
+			// Adjusts URLs
+			normalizeSource(bundle, bundlePath);
 
-      // Combines the source
-      concatSource(bundle);
+			// Combines the source
+			concatSource(bundle);
 
-	  var code = bundle.source.code, map;
-	  if(configuration.options.sourceMaps) {
-		  addSourceMapUrl(bundle);
-		  code = bundle.source.code;
-		  map = bundle.source.map;
-	  }
+			var code = bundle.source.code, map;
+			if(configuration.options.sourceMaps) {
+				addSourceMapUrl(bundle);
+				code = bundle.source.code;
+				map = bundle.source.map;
+			}
 
-      // Log the bundles
-      winston.info("BUNDLE: %s", bundleFilename(bundle));
-      winston.debug(Buffer.byteLength(code, "utf8") + " bytes");
+			// Log the bundles
+			winston.info("BUNDLE: %s", bundleFilename(bundle));
+			winston.debug(Buffer.byteLength(code, "utf8") + " bytes");
 
-      bundle.nodes.forEach(function(node) {
-        winston.info("+ %s", node.load.name);
-      });
+			bundle.nodes.forEach(function(node) {
+				winston.info("+ %s", node.load.name);
+			});
 
-      // Once a folder has been created, write out the bundle source
-      bundleDirDef.then(function() {
-        mkdirp(dirname(bundlePath), function(err) {
-          if (err) {
-            reject(err);
-          }
-          else {
-            fs.writeFile(bundlePath, code, function(err) {
-              if(err) {
-                reject(err);
-              } else {
-                if(!map) {
-                  resolve(bundle);
-				  return;
-                }
-                // Write out the source map
-                fs.writeFile(bundlePath+".map", map, function(err) {
-                  if(err) return reject(err);
-                  resolve(bundle);
-                });
-              }
-            });
-          }
-        });
+			// Once a folder has been created, write out the bundle source
+			bundleDirDef.then(function() {
+				mkdirp(dirname(bundlePath), function(err) {
+					if (err) {
+						reject(err);
+					}
+					else {
+						fs.writeFile(bundlePath, code, function(err) {
+							if(err) {
+								reject(err);
+							} else {
+								if(!map) {
+									resolve(bundle);
+									return;
+								}
+								// Write out the source map
+								fs.writeFile(bundlePath+".map", map, function(err) {
+									if(err) return reject(err);
+									resolve(bundle);
+								});
+							}
+						});
+					}
+				});
 
-      }).catch(function(err) {
-        reject(err);
-      });
-    }));
+			}).catch(function(err) {
+				reject(err);
+			});
+		}));
+	});
 
-  });
-
-  return Promise.all(builtBundleDeferreds);
-
+	return Promise.all(builtBundleDeferreds);
 };
 
 writeBundles.createWriteStream = function(){

--- a/lib/graph/minify.js
+++ b/lib/graph/minify.js
@@ -1,12 +1,12 @@
 var minifyJS = require('../buildTypes/minifyJS'),
-	minifyCSS = require('../buildTypes/minifyCSS'),
 	transformActiveSource = require("../node/transform_active_source");
-function minify(node, options){
+
+function minify(node, options) {
 	transformActiveSource(node,"minify-true", function(node, source){
-		var minifier = node.load.metadata.buildType === "css" ?
-				minifyCSS : minifyJS;
-		var result = minifier(source, options);
-		return result;
+		var buildType = node.load.metadata.buildType;
+
+		// skip css source files, css is minified after the bundle is concatenated
+		return buildType === "css" ? source : minifyJS(source, options);
 	});
 }
 

--- a/lib/graph/minify.js
+++ b/lib/graph/minify.js
@@ -12,9 +12,9 @@ function minify(node, options) {
 		} else {
 			var result;
 			try {
-				result = minifier(source, options);	
+				result = minifyJS(source, options);	
 			} catch(e) {
-				winston.warn('Error occured while minifying', node.load.address);
+				winston.warn("Error occured while minifying", node.load.address);
 				throw(e);
 			}
 			

--- a/test/css_paths/main.js
+++ b/test/css_paths/main.js
@@ -3,14 +3,14 @@ import 'folder/main.css!';
 import 'style.css!';
 
 function getFile(url, cb) {
-	var xhr = new XMLHttpRequest();              
-	xhr.open("GET", url, true);                             
+	var xhr = new XMLHttpRequest();
+	xhr.open("GET", url, true);
 	xhr.send(null);
 	xhr.onreadystatechange = function(){
 		if(xhr.readyState === 4) {
 			cb(xhr.responseText);
 		}
-	};                                       
+	};
 }
 var links = document.getElementsByTagName('link');
 
@@ -19,5 +19,3 @@ if(links.length) {
 		window.STYLE_CONTENT =  content;
 	});
 }
-
-

--- a/test/css_paths/prod.html
+++ b/test/css_paths/prod.html
@@ -1,6 +1,6 @@
 <body>
-	<script type="text/javascript" 
-		src='../../bower_components/steal/steal.js' 
+	<script type="text/javascript"
+		src="../../bower_components/steal/steal.js"
 		data-config="./config.js"
 		data-main="main"
 		data-env="production"></script>

--- a/test/minify/minify.js
+++ b/test/minify/minify.js
@@ -1,11 +1,12 @@
 import "main.css!";
+import "other.css!";
 
 "format cjs";
 
 var global = require("global");
 
 var thisObjectHasABigName = {
-	foo: "bar" 
+	foo: "bar"
 };
 
 module.exports = thisObjectHasABigName;

--- a/test/minify/other.css
+++ b/test/minify/other.css
@@ -1,0 +1,11 @@
+.foo {
+	background-color: red;
+}
+
+.bar {
+	background-color: black;
+}
+
+body {
+	display: none;
+}

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -11,7 +11,7 @@ var find = testHelpers.find;
 var open = testHelpers.open;
 
 describe("multi build", function(){
-    this.timeout(5000);
+	this.timeout(5000);
 
 	it("should work", function(done){
 		rmdir(__dirname+"/bundle/dist", function(error){
@@ -138,17 +138,21 @@ describe("multi build", function(){
 			}
 
 			multiBuild(config, { quiet: true }).then(function(){
-				var actual = fs.readFileSync(__dirname + "/minify/dist/bundles/minify.js", "utf8");
+				var actualJS = fs.readFileSync(__dirname + "/minify/dist/bundles/minify.js", "utf8");
+				var actualCSS = fs.readFileSync(__dirname + "/minify/dist/bundles/minify.css", "utf8");
 
-				var hasLongVariable = actual.indexOf("thisObjectHasABigName") !== -1;
-				var hasGlobalLongVariable = actual.indexOf("anotherVeryLongName") !== -1;
-				var hasDevCode = actual.indexOf("remove this") !== -1;
+				var hasLongVariable = actualJS.indexOf("thisObjectHasABigName") !== -1;
+				var hasGlobalLongVariable = actualJS.indexOf("anotherVeryLongName") !== -1;
+				var hasDevCode = actualJS.indexOf("remove this") !== -1;
+				var hasDupCSSSelectors = actualCSS.match(/body/g).length > 1;
 
 				assert(!hasLongVariable, "Minified source renamed long variable.");
 				assert(!hasGlobalLongVariable, "Minified source includes a global that was minified.");
 				assert(!hasDevCode, "Minified source has dev code removed.");
+				assert(!hasDupCSSSelectors, "Minified CSS should not include duplicated selectors");
 
-			}).then(done);
+				done();
+			});
 		});
 
 	});
@@ -171,11 +175,14 @@ describe("multi build", function(){
 			}
 
 			multiBuild(config, options).then(function(){
-				var actual = fs.readFileSync(__dirname + "/minify/dist/bundles/minify.js", "utf8");
+				var actualJS = fs.readFileSync(__dirname + "/minify/dist/bundles/minify.js", "utf8");
+				var actualCSS = fs.readFileSync(__dirname + "/minify/dist/bundles/minify.css", "utf8");
 
-				var hasLongVariable = actual.indexOf("thisObjectHasABigName") !== -1;
+				var hasDupCSSSelectors = actualCSS.match(/body/g).length > 1;
+				var hasLongVariable = actualJS.indexOf("thisObjectHasABigName") !== -1;
 
 				assert(hasLongVariable, "Source includes long variable name.");
+				assert(hasDupCSSSelectors, "Not minified CSS should include duplicated selectors");
 
 				done();
 			}).catch(function(e){
@@ -961,7 +968,8 @@ describe("multi build", function(){
 								assert.equal(part,"../../images/hero-ribbons.png", "reference is correct");
 								count++;
 							});
-							assert.equal(count, 3, "correct number of styles");
+							// the minifier will compact the selectors applying the same 'background-image' rule
+							assert.equal(count, 1, "correct number of styles");
 							close();
 						}, close);
 


### PR DESCRIPTION
Closes #88.

Instead of minifying each css node individually, this PR changes steal-tools to minify the concatenated bundle before writing. I tested this branch in my current app and got some interesting numbers:

- before:
652K	dist/bundles/bundle-a.css
268K	dist/bundles/bundle-b.css
192K	dist/bundles/bundle-a-b.css

- after
440K	dist/bundles/bundle-a.css
196K	dist/bundles/bundle-b.css
192K	dist/bundles/bundle-a-b.css

There is some noise in the `write_bundles` file b/c I made some changes to the indentation, here is the interesting diff https://github.com/stealjs/steal-tools/commit/8c3da0e207bd88ba57f1b6dcc240678c6368b9ad. 