### PR TITLE
Ensure shared bundle names are reasonably pretty

### DIFF
--- a/lib/bundle/name.js
+++ b/lib/bundle/name.js
@@ -12,8 +12,14 @@ function deNpm(name) {
 }
 
 var filename = function(uri){
-		var lastSlash = uri.lastIndexOf("/"),
-			matches = ( lastSlash == -1 ? uri : uri.substr(lastSlash+1) ).match(/^[\w-\s\.]+/);
+		var lastSlash = uri.lastIndexOf("/");
+		var sub;
+		if(lastSlash == -1) {
+			sub = uri;
+		} else {
+			sub = uri.substr(lastSlash + 1);
+		}
+		var matches = deNpm(sub).match(/^[\w-\s\.]+/);
 		return matches ? matches[0] : "";
 	},
 	pluginPart = function(name){

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -1355,16 +1355,21 @@ describe("multi build", function(){
 	describe("npm with directories.lib", function(){
 		beforeEach(function(done){
 			asap(rmdir)(__dirname + "/npm-directories/dist").then(function(){
+				return multiBuild({
+					config: __dirname + "/npm-directories/package.json!npm"
+				}, {
+					quiet: true
+				});
+			}).then(function(){
 				done();
 			}, done);
 		});
 
-		it("builds and works", function(done){
-			multiBuild({
-				config: __dirname + "/npm-directories/package.json!npm"
-			}, {
-				quiet: true
-			}).then(function(){
+		it("creates pretty shared bundle names", function(done){
+			var sharedBundleName = __dirname+"/npm-directories/dist/bundles/" +
+				"category-home.js";
+			fs.exists(sharedBundleName, function(exists){
+				assert.ok(exists, "shared bundle name was created");
 				done();
 			});
 		});

--- a/test/npm-directories/package.json
+++ b/test/npm-directories/package.json
@@ -7,7 +7,9 @@
       "lib": "src"
     },
     "bundle": [
-      "npm-dependencies/other"
+      "npm-dependencies/other",
+	  "npm-dependencies/home",
+	  "npm-dependencies/category"
     ]
   }
 }

--- a/test/npm-directories/src/carousel.js
+++ b/test/npm-directories/src/carousel.js
@@ -1,0 +1,1 @@
+module.exports = "this is a carousel";

--- a/test/npm-directories/src/category.js
+++ b/test/npm-directories/src/category.js
@@ -1,0 +1,1 @@
+require("./carousel");

--- a/test/npm-directories/src/home.js
+++ b/test/npm-directories/src/home.js
@@ -1,0 +1,1 @@
+require("./carousel");


### PR DESCRIPTION
This fixes an issue where if you have bundles like:

```js
bundles: [
  "myapp/one",
  "myapp/two"
]
```

That had a shared dependency it would produce a shared bundle named `myapp-myapp.js`. This fixes it to be `one-two.js` instead. Closes #339