### PR TITLE
Allow passing in transpile option

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -21,45 +21,10 @@ specified in [steal-tools.SystemConfig], an additional `bundlesPath` is sometime
  - Relative to [System.baseURL baseURL] - bundlesPath looks like: "packages", "foo/bar".
  
   
-@param {{}} [options]
+@param {steal-tools.BuildOptions} [options]
 
 Specifies the behavior of the build.
-
-  @option {Boolean} [minify=true] Minifies the built packages.  Defaults to `true`.
   
-  @option {Boolean} [debug=false] `true` turns on debug messages. Defaults to `false`.
-  
-  @option {Boolean} [quiet=false] No logging.  Defaults to `false`.
-  
-  @option {Boolean} [bundleSteal=false] Set to true to include steal in the main bundle.
-
-  @option {steal-tools.BundleAssetsOptions|Boolean} [bundleAssets=false] Set to true to have assets from your project bundled into your dist folder.
-  
-  @option {Array.<moduleName>} bundle An array of module names that should be
-  progressively loaded.
-  
-  @option {Number} [bundleDepth=3] The maximum number of bundles that need to be loaded
-  for any `bundle` module. Defaults to `3`.
-  
-  @option {Number} [mainDepth=3] The maximum number of bundles that will be loaded for any `main`
-  module. Defaults to `3`.
-  
-  @option {Boolean} [removeDevelopmentCode=true] Remove any development code from the bundle specified 
-  using `//!steal-remove-start`, and `//!steal-remove-end` comments.
-  
-  @option {Object} [cleanCSSOptions] A hash of options to customize the minification of css files. 
-  All available options are listed in the [clean-css documentation](https://github.com/jakubpawlowicz/clean-css#how-to-use-clean-css-programmatically).
-  
-  @option {Object} [uglifyOptions] A hash of options to customize the minification of JavaScript files. StealTools uses the 
-  top-level `minify` function of uglify-js, and the available options are listed [here](https://github.com/mishoo/UglifyJS2#the-simple-way).
-  The option `fromString` is used internally and will always be `true`; any other value will be ignored.
-
-  @option {Boolean} [sourceMaps=false] Generate source maps alongside your bundles.
-
-  @option {Boolean} [sourceMapsContent=false] Include the original source contents in the generated source maps. Use this option if your production environment doesn't have access to the source files. Will result in a larger source maps size but will cause fewer requests.
-
-  @option {Boolean} [watch=false] Actives watch mode which will continuously build as you develop your application.
-
 @return {(Promise<steal-tools.BuildResult>|Stream<steal-tools.BuildResult>)} Either a Promise that resolves when the build is complete or a Stream that will send `data` events every time a rebuild is complete. By default a Promise is returned, unless the `watch` option is enabled.
 
 @body

--- a/doc/types/build-options.md
+++ b/doc/types/build-options.md
@@ -7,12 +7,35 @@ Options used to configure the build process.
 
 @option {Boolean} [bundleSteal=false] Sets whether StealJS will be included in the built file. Enabling this option will allow you to limit the initial request to just one script.
 
-@option {Boolean} [removeDevelopmentCode=true] Sets whether development code (code wrapped with `@steal-remove-{start/stop}`) will be removed.
+@option {Boolean} [debug=false] `true` turns on debug messages. Defaults to `false`.
 
-@option {Array<String>} ignore Specify modules to exclude in the final output. For example, if you wanted to load jQuery from a cdn, you would provide this option:
+@option {Boolean} [quiet=false] No logging.  Defaults to `false`.
 
-    {
-      ignore: [ "jquery" ]
-    }
+@option {steal-tools.BundleAssetsOptions|Boolean} [bundleAssets=false] Set to true to have assets from your project bundled into your dist folder.
 
-@option {steal-tools.format} format Specifies a format for transpiling the dependency graph. In the multiBuild, all code is automatically transpiled to **amd** format. In [steal-tools.transform], the default is to **global**.
+@option {Array.<moduleName>} bundle An array of module names that should be
+progressively loaded.
+
+@option {Number} [bundleDepth=3] The maximum number of bundles that need to be loaded
+for any `bundle` module. Defaults to `3`.
+
+@option {Number} [mainDepth=3] The maximum number of bundles that will be loaded for any `main`
+module. Defaults to `3`.
+
+@option {Boolean} [removeDevelopmentCode=true] Remove any development code from the bundle specified 
+using `//!steal-remove-start`, and `//!steal-remove-end` comments.
+
+@option {Object} [cleanCSSOptions] A hash of options to customize the minification of css files. 
+All available options are listed in the [clean-css documentation](https://github.com/jakubpawlowicz/clean-css#how-to-use-clean-css-programmatically).
+
+@option {Object} [uglifyOptions] A hash of options to customize the minification of JavaScript files. StealTools uses the 
+top-level `minify` function of uglify-js, and the available options are listed [here](https://github.com/mishoo/UglifyJS2#the-simple-way).
+The option `fromString` is used internally and will always be `true`; any other value will be ignored.
+
+@option {Boolean} [sourceMaps=false] Generate source maps alongside your bundles.
+
+@option {Boolean} [sourceMapsContent=false] Include the original source contents in the generated source maps. Use this option if your production environment doesn't have access to the source files. Will result in a larger source maps size but will cause fewer requests.
+
+@option {steal-tools.BuildOptions.transpile} [transpile] A function that handles the transpiling of ES6 source to a format for production.
+
+@option {Boolean} [watch=false] Actives watch mode which will continuously build as you develop your application.

--- a/doc/types/compile-options.md
+++ b/doc/types/compile-options.md
@@ -1,0 +1,14 @@
+@typedef {Object} steal-tools.BuildOptions.compileOptions TranspileCompileOptions
+@parent steal-tools.BuildOptions.transpiler
+
+An object of options passed into your custom [steal-tools.BuildOptions.transpile] function.
+
+@option {String} source The source code needing to be transpiled.
+
+@option {String} module A module format needed to be transpiled to.
+
+It is either:
+
+* **commonjs**
+* **amd**
+* **system**

--- a/doc/types/transpiler.md
+++ b/doc/types/transpiler.md
@@ -1,0 +1,46 @@
+@function steal-tools.BuildOptions.transpile Transpile
+@parent steal-tools.types
+
+Allows the ability to completely control the transpiling of ES2015 source down to another format for production bundling (usually to AMD).
+
+@signature `transpile(source, compileOptions)`
+
+@param {String} source The ES2015 source code to be transpiled.
+
+@param {steal-tools.BuildOptions.compileOptions} compileOptions The options needed to be used to do the transpile, such as the format being transpiled to, and whether source maps are needed.
+
+@return {steal-tools.source.object} An object containing `code` and (optionally) `map` properties.
+
+@body
+
+The **transpile** option gives you complete control over transpiling. After StealTools has created a graph of your project's dependencies it then goes through each and transpiles them into a common format, usually AMD for the multi-build.
+
+If you're using a specific version of Traceur, Babel, or a different transpiler altogether, you might want to use this so that you can do your own transpiling.
+
+Here's an example of usage:
+
+```js
+var Babel = require("babel-core");
+var stealTools = require("steal-tools");
+
+var mapFormat = {
+	'commonjs': 'common',
+	'amd': 'amd'
+};
+
+var transpile = function(source, compileOptions){
+	var babelOptions = {
+		modules: mapFormat[compileOptions.module],
+		sourceMap: compileOptions.sourceMaps || false
+	};
+
+	return babel.transform(source, opts);
+};
+
+
+stealTools.build({
+	config: __dirname + "/package.json!npm"
+}, {
+	transpile: transpile
+});
+```

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "through2": "^2.0.0",
     "tmp": "0.0.26",
     "traceur": "0.0.91",
-    "transpile": "^0.9.0",
+    "transpile": "^0.9.4",
     "uglify-js": "~2.4.13",
     "urix": "^0.1.0",
     "winston": "^0.7.3",

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -103,6 +103,39 @@ describe("multi build", function(){
 		});
 	});
 
+	it("allows you to transpile modules on your own", function(done){
+		rmdir(__dirname + "/self_transpile/dist", function(error){
+			if(error) {
+				return done(error);
+			}
+
+			multiBuild({
+				config: __dirname + "/self_transpile/config.js",
+				main: "index"
+			}, {
+				quiet: true,
+				minify: false,
+				transpile: function(source){
+					if(source.indexOf("import") >= 0) {
+						source = "require('two');";
+					} else {
+						source = '"format amd";';
+					}
+					return { code: source };
+				}
+			}).then(function(){
+				fs.readFile(__dirname + "/self_transpile/dist/bundles/index.js",
+					"utf8", function(error, contents){
+					if(error) return done(error);
+
+					var hasRequire = /require\('two'\)/.test(contents);
+					assert.ok(hasRequire, "converted the way my transpile does");
+					done();
+				});
+			});
+		});
+	});
+
 	it("doesn't include the traceur runtime if it's not being used", function(done){
 		rmdir(__dirname + "/simple-es6/dist", function(error){
 			if(error) {

--- a/test/self_transpile/config.js
+++ b/test/self_transpile/config.js
@@ -1,0 +1,1 @@
+"format cjs";

--- a/test/self_transpile/index.js
+++ b/test/self_transpile/index.js
@@ -1,0 +1,1 @@
+import two from "./two";

--- a/test/self_transpile/two.js
+++ b/test/self_transpile/two.js
@@ -1,0 +1,1 @@
+"format es6";


### PR DESCRIPTION
This adds the option so that the user can pass in their own transpile. It looks like this:

```js
stealTools.build({
  config: __dirname + "/package.json!npm"
}, {
  transpile: function(source, compileOptions){
    return {
      code: doSomething(code)
    }
  }
}
```

Docs included. This closes #354