### PR TITLE
Reuse some config when loading bundles

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "steal-tools",
   "version": "0.14.0-pre.0",
   "devDependencies": {
-    "steal": "^0.14.0-pre.6",
+    "steal": "^0.14.0-pre.7",
     "jquery": "~1.10.0",
     "less" : "^2.4.0"
   }

--- a/lib/graph/make_graph_with_bundles.js
+++ b/lib/graph/make_graph_with_bundles.js
@@ -20,7 +20,7 @@ function addBundle (node, bundle) {
 
 // merges everything in `newGraph` into `masterGraph` and make sure it lists
 // `bundle` as one of its bundles.
-function mergeIntoMasterAndAddBundle (masterGraph, newGraph, bundle) {
+function mergeIntoMasterAndAddBundle (masterGraph, newGraph, bundle, loader) {
 	for(var name in newGraph) {
 		if(!masterGraph[name]) {
 			masterGraph[name] = newGraph[name];
@@ -34,7 +34,22 @@ function mergeIntoMasterAndAddBundle (masterGraph, newGraph, bundle) {
 				addBundle(masterGraph[name], bundle);
 			});
 		}
+		// If this is the configMain like package.json!npm we need to override
+		// the source every time because it continuously changes.
+		else if(masterGraph[name] && name === loader.configMain) {
+			var node = masterGraph[name];
+			node.load.source = newGraph[name].load.source;
+		}
 		addBundle(masterGraph[name], bundle);
+	}
+}
+
+function mergeConfigForNextBundle(system, loader){
+	if(loader.npmContext) {
+		system.npmContext = loader.npmContext;
+	}
+	if(loader.npmParentMap) {
+		system.npmParentMap = loader.npmParentMap;
 	}
 }
 
@@ -84,6 +99,7 @@ var makeBundleGraph = module.exports = function(config, options){
 
 		// Get config for virtual modules
 		options.system = createModuleConfig(loader);
+		mergeConfigForNextBundle(options.system, data.loader);
 
 		// Get the next bundle name and gets a graph for it.
 		// Merges those nodes into the masterGraph
@@ -103,7 +119,9 @@ var makeBundleGraph = module.exports = function(config, options){
 				var copy = _.clone(cfg, true);
 				copy.main = nextBundle;
 				return dependencyGraph(copy, options).then(function(data){
-					mergeIntoMasterAndAddBundle(masterGraph, data.graph, nextBundle);
+					mergeIntoMasterAndAddBundle(masterGraph, data.graph,
+												nextBundle, data.loader);
+					mergeConfigForNextBundle(options.system, data.loader);
 					return getNextGraphAndMerge();
 				});
 			}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "moment": "^2.10.2",
     "pdenodeify": "^0.1.0",
     "source-map": "https://github.com/stealjs/source-map/archive/0.4.2-bitovi.1.tar.gz",
-    "steal": "^0.14.0-pre.6",
+    "steal": "^0.14.0-pre.7",
     "steal-bundler": "^0.2.4",
     "system-parse-amd": "0.0.2",
     "through2": "^2.0.0",

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -828,6 +828,33 @@ describe("multi build", function(){
 		});
 	});
 
+	it("Is able to load progressively loaded app with progressively loaded pacakge.json data", function(done){
+		rmdir(__dirname+"/progressive_package/dist", function(error){
+			if(error) return done(error);
+
+			multiBuild({
+				config: __dirname + "/progressive_package/package.json!npm"
+			}, {
+				minify: false,
+				quiet: true
+			}).then(function(){
+				open("test/progressive_package/prod.html",
+					 function(browser, close){
+					find(browser, "MODULE", function(module){
+						var a = module.a;
+						var b = module.b;
+						assert.equal(a.name, "dep2", "loaded dep2");
+						assert.equal(a.dep3, "dep3", "loaded dep3");
+
+						assert.equal(b.name, "dep4", "loaded dep4");
+						assert.equal(b.dep5, "dep5", "loaded dep5");
+						close();
+					}, close);
+				}, done);
+			});
+		});
+	});
+
 	describe("with plugins", function(){
 		it("work on the client", function(done){
 			this.timeout(5000);

--- a/test/progressive_package/bundleA.js
+++ b/test/progressive_package/bundleA.js
@@ -1,0 +1,3 @@
+var dep = require("dep2");
+
+module.exports = dep;

--- a/test/progressive_package/bundleB.js
+++ b/test/progressive_package/bundleB.js
@@ -1,0 +1,3 @@
+var dep = require("dep4");
+
+module.exports = dep;

--- a/test/progressive_package/dev.html
+++ b/test/progressive_package/dev.html
@@ -1,0 +1,2 @@
+<script src="../../bower_components/steal/steal.js"
+config="package.json!npm"></script>

--- a/test/progressive_package/main.js
+++ b/test/progressive_package/main.js
@@ -1,0 +1,14 @@
+require("dep1");
+
+System.import("bundleA").then(function(a){
+	System.import("bundleB").then(function(b){
+		window.MODULE = {
+			a: a,
+			b: b
+		};
+
+		if(System.isEnv("development")) {
+			console.log("bundles loaded", window.MODULE);
+		}
+	});
+});

--- a/test/progressive_package/node_modules/dep1/main.js
+++ b/test/progressive_package/node_modules/dep1/main.js
@@ -1,0 +1,1 @@
+module.exports = "dep1";

--- a/test/progressive_package/node_modules/dep1/package.json
+++ b/test/progressive_package/node_modules/dep1/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dep1",
+  "main": "main.js",
+  "version": "1.0.0"
+}

--- a/test/progressive_package/node_modules/dep2/main.js
+++ b/test/progressive_package/node_modules/dep2/main.js
@@ -1,0 +1,4 @@
+module.exports = {
+	name: "dep2",
+	dep3: require("dep3")
+};

--- a/test/progressive_package/node_modules/dep2/node_modules/dep3/main.js
+++ b/test/progressive_package/node_modules/dep2/node_modules/dep3/main.js
@@ -1,0 +1,1 @@
+module.exports = "dep3";

--- a/test/progressive_package/node_modules/dep2/node_modules/dep3/package.json
+++ b/test/progressive_package/node_modules/dep2/node_modules/dep3/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dep3",
+  "main": "main.js",
+  "version": "1.0.0"
+}

--- a/test/progressive_package/node_modules/dep2/package.json
+++ b/test/progressive_package/node_modules/dep2/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "dep2",
+  "main": "main.js",
+  "version": "1.0.0",
+  "dependencies": {
+    "dep3": "1.0.0"
+  }
+}

--- a/test/progressive_package/node_modules/dep4/main.js
+++ b/test/progressive_package/node_modules/dep4/main.js
@@ -1,0 +1,4 @@
+module.exports = {
+	name: "dep4",
+	dep5: require("dep5")
+};

--- a/test/progressive_package/node_modules/dep4/node_modules/dep5/main.js
+++ b/test/progressive_package/node_modules/dep4/node_modules/dep5/main.js
@@ -1,0 +1,1 @@
+module.exports = "dep5";

--- a/test/progressive_package/node_modules/dep4/node_modules/dep5/package.json
+++ b/test/progressive_package/node_modules/dep4/node_modules/dep5/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dep5",
+  "main": "main.js",
+  "version": "1.0.0"
+}

--- a/test/progressive_package/node_modules/dep4/package.json
+++ b/test/progressive_package/node_modules/dep4/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "dep4",
+  "main": "main.js",
+  "version": "1.0.0",
+  "dependencies": {
+    "dep5": "1.0.0"
+  }
+}

--- a/test/progressive_package/package.json
+++ b/test/progressive_package/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "app",
+  "main": "main.js",
+  "version": "1.0.0",
+  "dependencies": {
+    "dep1": "1.0.0",
+	"dep2": "1.0.0",
+	"dep4": "1.0.0"
+  },
+  "system": {
+    "bundle": ["bundleA", "bundleB"]
+  }
+}

--- a/test/progressive_package/prod.html
+++ b/test/progressive_package/prod.html
@@ -1,0 +1,3 @@
+<script src="../../bower_components/steal/steal.js"
+env="window-production"
+config="package.json!npm" main="main"></script>


### PR DESCRIPTION
This fixes #365. Some configuration might need to be reused when loading multiple bundles in multiple loaders. With the new progressive loading of package.jsons we need to keep the `npmContext` between loaders because each bundle will have a different set of NPM dependencies, and we need to build them **all** in the final output.