### PR TITLE
Remove dependency on babel

### DIFF
--- a/lib/trace.js
+++ b/lib/trace.js
@@ -1,5 +1,3 @@
-var nodeRequire = require;
-
 
 var trace = function(System, BuildSystem, onFulfilled){
 
@@ -37,13 +35,12 @@ var trace = function(System, BuildSystem, onFulfilled){
 		var pluginName = load.metadata.pluginName;
 
 		if(load.name === "babel") {
-			return {
-				deps: [],
-				execute: function(){
-					var value = nodeRequire("babel");
-					return System.newModule(value);
-				}
-			};
+			load.metadata.format = "global";
+			// If there are no dependants prevent this from being added to
+			// the dependancy graph.
+			if(System.getDependants(load.name).length === 0) {
+				load.metadata.includeInDependencyGraph = false;
+			}
 		}
 
 		var res = systemInstantiate.apply(this, arguments);
@@ -63,7 +60,9 @@ var trace = function(System, BuildSystem, onFulfilled){
 				load.metadata.format = "cjs";
 			}
 
-			onFulfilled(load, deps, dependencies);
+			if(load.metadata.includeInDependencyGraph !== false) {
+				onFulfilled(load, deps, dependencies);
+			}
 
 			return instantiateResult;
 		});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "web": "http://bitovi.com/"
   },
   "dependencies": {
-    "babel": "^5.8.23",
     "chokidar": "^1.0.1",
     "clean-css": "3.1.8",
     "colors": "^0.6.2",

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -628,6 +628,10 @@ describe("multi build", function(){
 				quiet: true,
 				minify: false
 			}).then(function(){
+				var code = fs.readFileSync(__dirname+"/babel/dist/bundles/main.js",
+										   "utf8");
+				assert(!/\*babel\*/.test(code), "babel not included in the code");
+
 				open("test/babel/prod.html",function(browser, close){
 					find(browser,"MODULE", function(module){
 						assert(true, "module");


### PR DESCRIPTION
This was added when I implemented the Trace extension. Isn't needed, Steal is able to load the browser-based babel and use that for transpiling just fine. Closes #363