### PR TITLE
Don't mutate the `main` array provided to the build

### DIFF
--- a/lib/graph/make_graph_with_bundles.js
+++ b/lib/graph/make_graph_with_bundles.js
@@ -4,6 +4,8 @@ var normalizeBundle = require("../loader/normalize_bundle");
 var through = require("through2");
 var fs = require("fs-extra");
 
+var slice = Array.prototype.slice;
+
 function addBundleOnEveryModule (graph, bundle){
 	for(var name in graph) {
 		addBundle( graph[name],bundle );
@@ -62,7 +64,7 @@ var makeBundleGraph = module.exports = function(config, options){
 
 	var cfg = _.clone(config, true);
 	if( Array.isArray(cfg.main) ) {
-		bundleNames = cfg.main;
+		bundleNames = slice.call(cfg.main);
 		cfg.main = bundleNames.shift();
 	}
 	// Get the first dependency graph

--- a/test/multi-main/npm_app_a.html
+++ b/test/multi-main/npm_app_a.html
@@ -1,0 +1,6 @@
+<script 
+	src="../../node_modules/steal/steal.js" 
+	main="app_a"
+	base-url="dist"
+	bundles-path="bundles"
+	env="production"></script>

--- a/test/multi-main/npm_app_b.html
+++ b/test/multi-main/npm_app_b.html
@@ -1,0 +1,6 @@
+<script 
+	src="../../node_modules/steal/steal.js" 
+	main="app_b"
+	base-url="dist"
+	bundles-path="bundles"
+	env="production"></script>

--- a/test/multi-main/npm_app_c.html
+++ b/test/multi-main/npm_app_c.html
@@ -1,0 +1,6 @@
+<script 
+	src="../../node_modules/steal/steal.js" 
+	main="app_c"
+	base-url="dist"
+	bundles-path="bundles"
+	env="production"></script>

--- a/test/multi-main/npm_app_d.html
+++ b/test/multi-main/npm_app_d.html
@@ -1,0 +1,6 @@
+<script 
+	src="../../node_modules/steal/steal.js" 
+	main="app_d"
+	base-url="dist"
+	bundles-path="bundles"
+	env="production"></script>

--- a/test/multi-main/package.json
+++ b/test/multi-main/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "multi-main",
+	"main": "main",
+	"version": "1.0.0"
+	
+}

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -1109,7 +1109,7 @@ describe("multi build", function(){
 
 				multiBuild({
 					config: __dirname+"/multi-main/config.js",
-					main: mains
+					main: mains.slice()
 				}, {
 					quiet: true
 					//verbose: true
@@ -1149,6 +1149,79 @@ describe("multi build", function(){
 				});
 			});
 		});
+
+		it("works with npm plugin", function(done){
+			var mains = [
+				"app_a","app_b",
+				"app_c","app_d"
+			],
+				ab = {name: "a_b"},
+				cd = {name: "c_d"},
+				all = {name: "all"},
+				results = {
+					app_a: {
+						name: "a", ab: ab, all: all
+					},
+					app_b: {
+						name: "b", ab: ab, all: all
+					},
+					app_c:{
+						name: "b", cd: cd, all: all
+					},
+					app_d:{
+						name: "d", cd: cd, all: all
+					}
+				};
+
+			rmdir(__dirname+"/multi-main/dist", function(error){
+				if(error){
+					done(error);
+					return;
+				}
+
+				multiBuild({
+					config: __dirname+"/multi-main/package.json!npm",
+					main: mains.slice()
+				}, {
+					quiet: true,
+					minify: false
+				}).then(function(data){
+
+					var checkNext = function(next){
+						if(next) {
+							open("test/multi-main/npm_"+next+".html",function(browser, close){
+								find(browser,"app", function(app){
+
+									assert(true, "got app");
+									comparify(results[next], app);
+									close();
+
+								}, close);
+
+							}, function(err){
+								if(err) {
+									done(err);
+								} else {
+									var mynext = mains.shift();
+									if(mynext) {
+										setTimeout(function(){
+											checkNext(mynext)
+										},1);
+									} else {
+										done();
+									}
+								}
+							});
+						}
+					};
+					checkNext( mains.pop() );
+
+				}).catch(function(e){
+					done(e);
+				});
+			});
+		});
+
 
 		it("works with steal bundled", function(done){
 			var mains = ["app_a","app_b","app_c","app_d"],


### PR DESCRIPTION
When doing a multi-main build make_graph_with_bundles was mutating the `main` which caused the first main to be excluded from the build.

This fixes #375