### PR TITLE
Add a test for eachModule

### DIFF
--- a/lib/build/export.js
+++ b/lib/build/export.js
@@ -13,7 +13,7 @@ var mergeModules = function(items, modules){
 	while(i < items.length) {
 		item = items[i];
 		if(typeof item === "object" && !(item instanceof RegExp) ) {
-			var moduleNames = _.map( _.where(modules, item), "moduleName");
+			var moduleNames = _.map( _.filter(modules, item), "moduleName");
 			items.splice.apply(items,[i,1].concat(moduleNames));
 			i = i + moduleNames.length;
 		} else {
@@ -157,7 +157,7 @@ module.exports = function(config, defaults, modules){
 				if(Array.isArray( out.output.eachModule) ) {
 					mods = normalized(out.output.eachModule);
 				} else {
-					mods = normalized(_.map( _.where(modules, out.output.eachModule), "moduleName"));
+					mods = normalized(_.map( _.filter(modules, out.output.eachModule), "moduleName"));
 				}
 
 				doTransform = function(mods, ignores){

--- a/test/export_test.js
+++ b/test/export_test.js
@@ -157,6 +157,41 @@ describe("export", function(){
 		}, done);
 	});
 
+	describe("eachModule", function(){
+		it("works", function(done){
+			stealExport({
+				system: {
+					main: "pluginifier_builder/pluginify",
+					config: __dirname+"/stealconfig.js"
+				},
+				options: {
+					quiet: true
+				},
+				"outputs": {
+					"basics standalone": {
+						eachModule: ["basics/module/module"],
+						dest: function(){
+							return __dirname+"/out/basics.js"
+						},
+						minify: false
+					}
+				}
+			}).then(function(){
+				open("test/pluginifier_builder/index.html",
+					 function(browser, close){
+
+					find(browser,"RESULT", function(result){
+						assert.ok(result.module, "has module");
+						assert.ok(result.cjs,"has cjs module");
+						assert.equal(result.name, "pluginified");
+						close();
+					}, close);
+				}, done);
+			}, done);
+
+		});
+	});
+
 	describe("helpers", function(){
 		beforeEach(function(done) {
 			rmdir(path.join(__dirname, "pluginifier_builder_helpers", "node_modules"), function(error){


### PR DESCRIPTION
In export eachModule was using `_.where` which was removed from lodash. This adds a test that catches the bug and also fixes it. Closes #380