### PR TITLE
In transform, set local steal to "build-development"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ test/pluginifier_builder_helpers/cjs/
 test/pluginifier_builder_helpers/browserify-out.js
 test/6to5/dist
 test/bundle_assets/dist
+test/live_reload/out.js

--- a/lib/build/transform.js
+++ b/lib/build/transform.js
@@ -26,7 +26,10 @@ var toss = function(e){
 
 var transformImport = function(config, transformOptions){
 	transformOptions = _.assign(transformOptions||{}, {
-		useNormalizedDependencies: true
+		useNormalizedDependencies: true,
+		localStealConfig: {
+			env: "build-development"
+		}
 	});
 	if(transformOptions.sourceMaps) {
 		_.assign(config, {

--- a/test/live_reload/plugin.html
+++ b/test/live_reload/plugin.html
@@ -1,0 +1,1 @@
+<script src="out.js"></script>

--- a/test/transform_test.js
+++ b/test/transform_test.js
@@ -222,5 +222,29 @@ describe("transformImport", function(){
 			});
 		});
 	});
+
+	it("Works with projects using live-reload", function(done){
+		rmdir(__dirname + "/live-reload/out.js", function(error){
+			if(error) { return done(error); }
+
+			transformImport({
+				config: __dirname + "/live_reload/package.json!npm"
+			}, {
+				quiet: true
+			}).then(function(transform){
+				var out = transform(null, { minify: false }).code;
+				fs.writeFile(__dirname + "/live_reload/out.js", out, function(error){
+					if(error) { return done(error); }
+
+					open("test/live_reload/plugin.html", function(browser, close){
+						find(browser, "MODULE", function(result){
+							assert.equal(result.foo, "bar", "works");
+							close();
+						}, close);
+					}, done);
+				});
+			});
+		});
+	});
 });
 


### PR DESCRIPTION
This means plugins that check `loader.isPlatform("build")` will see that they
are running in the build. Closes #395