### PR TITLE
Bundle naming

### DIFF
--- a/lib/bundle/name.js
+++ b/lib/bundle/name.js
@@ -135,8 +135,9 @@ function getName(bundle) {
 		};
 	}
 
-	var bundleName,
-			dirName = "bundles/";
+	var dirName = "bundles/",
+		shortened,
+		bundleName;
 
 	// remove trailing and leading parts
 	var bundleNames = bundle.bundles.map(function(appName){
@@ -169,7 +170,7 @@ function getName(bundle) {
 
 		// concat multiple bundles into one shortened filename,
 		// for that use only the last part of each modulepath
-		var shortened = bundleNames.map(function(l){
+		shortened = bundleNames.map(function(l){
 			return filename(l);
 		}).join('-');
 

--- a/lib/bundle/name.js
+++ b/lib/bundle/name.js
@@ -48,7 +48,7 @@ var filename = function(uri){
 		} else {
 			sub = uri.substr(lastSlash + 1);
 		}
-		var matches = deNpm(sub)["path"].match(/^[\w-\s\.]+/);
+		var matches = deNpm(sub).path.match(/^[\w-\s\.]+/);
 		return matches ? matches[0] : "";
 	},
 	pluginPart = function(name){
@@ -93,7 +93,7 @@ function getName(bundle) {
 	var packages = [];
 	var bundleNames = bundle.bundles.map(function(appName){
 		appName = appName.removeTrailing('/').removeTrailing('.js');
-		packages.push(deNpm(appName)['package']);
+		packages.push(deNpm(appName).package);
 		return appName;
 	});
 	packages = _.uniq(packages);
@@ -128,7 +128,7 @@ function getName(bundle) {
 			shortened = pluginResource(shortened);
 			// for the shortened we only want the path of the project
 			if(isNpm(shortened)) {
-				shortened = deNpm(shortened)['path'];
+				shortened = deNpm(shortened).path;
 			}
 
 			// e.g. index.stache
@@ -142,7 +142,7 @@ function getName(bundle) {
 	// using directories.lib
 	// so dirName needs to be packageName/modulePath
 	if(isNpm(bundleNames[0])) {
-		dirName += deNpm(bundleNames[0])["package"] + "/";
+		dirName += deNpm(bundleNames[0]).package + "/";
 	}
 
 	var buildType = bundle.buildType || "js",
@@ -153,7 +153,7 @@ function getName(bundle) {
 
 	if(!usedBundleNames[shortened]){
 		usedBundleNames[shortened] = true;
-		return dirName+deNpm(shortened+buildTypeSuffix)["path"];
+		return dirName+deNpm(shortened+buildTypeSuffix).path;
 	} else if(shortened.length > 50){
 		return dirName+shortened.substr(0,50)+"-"+bundleNames.length+"-"+(bundleCounter++)+buildTypeSuffix;
 	} else {

--- a/lib/bundle/name.js
+++ b/lib/bundle/name.js
@@ -27,7 +27,7 @@ function deNpm(name) {
 		'package': modulePackage,
 		'version': moduleVersion,
 		'path': modulePath
-	}
+	};
 }
 
 /**

--- a/lib/bundle/name.js
+++ b/lib/bundle/name.js
@@ -1,16 +1,45 @@
-var crypto = require('crypto');
+var crypto = require('crypto'),
+	_ = require('lodash'),
+	winston = require('winston');
 
 var npmNameExp = /.+@.+#.+/;
+/**
+ * is a npm module name?
+ * do not support npm scoping!
+ * @param name
+ * @returns {boolean}
+ */
 function isNpm(name) {
 	return npmNameExp.test(name);
 }
 
+/**
+ * get the path of a npm module
+ * {packagename}@{version}#{path}
+ * @param name
+ * @returns {*}
+ */
 function deNpm(name) {
-	if(!isNpm(name)) return name;
+	var modulePackage = name.substr(0, name.indexOf("@"));
+	var moduleVersion = name.substring(name.indexOf("@")+1, name.indexOf("#"));
 	var modulePath = name.substr(name.indexOf("#")+1);
-	return modulePath;
+	return {
+		'package': modulePackage,
+		'version': moduleVersion,
+		'path': modulePath
+	}
 }
 
+/**
+ * get the last part of a module path
+ * if a npm package is provided
+ * e.g.
+ * main/bar/foo => foo
+ * packagename@1.0.0#foo/bar => bar
+ *
+ * @param uri
+ * @returns {string}
+ */
 var filename = function(uri){
 		var lastSlash = uri.lastIndexOf("/");
 		var sub;
@@ -19,7 +48,7 @@ var filename = function(uri){
 		} else {
 			sub = uri.substr(lastSlash + 1);
 		}
-		var matches = deNpm(sub).match(/^[\w-\s\.]+/);
+		var matches = deNpm(sub)["path"].match(/^[\w-\s\.]+/);
 		return matches ? matches[0] : "";
 	},
 	pluginPart = function(name){
@@ -36,50 +65,95 @@ var filename = function(uri){
 	};
 
 var bundleCounter = 0;
+var usedBundleNames = {};
 
+/**
+ * get the name of a bundle
+ * @param bundle
+ * @returns {string}
+ */
 function getName(bundle) {
-	var usedBundleNames = {};
+
+	/**
+	 * add a prototype method to String
+	 * @param whatever
+	 * @returns {string}
+	 */
+	String.prototype.removeTrailing = function (whatever) {
+		var result = this;
+		if(this.substr((-1 * whatever.length)) === whatever) {
+			result = this.substr(0, this.length - (1 * whatever.length));
+		}
+		return result+"";
+	};
+
 	var dirName = "bundles/";
 
+	// remove trailing parts we do not need
+	var packages = [];
 	var bundleNames = bundle.bundles.map(function(appName){
-		return (appName+"").replace(".js","");
+		appName = appName.removeTrailing('/').removeTrailing('.js');
+		packages.push(deNpm(appName)['package']);
+		return appName;
 	});
+	packages = _.uniq(packages);
 
+	if(packages.length > 1) {
+		winston.warn("There is two or more different package names inside the bundles array." +
+			"The destination folder is set to "+dirName+'/'+packages.shift());
+	}
+
+	// concat multiple bundles into one shortened filename,
+	// for that use only the last part of each modulepath
+	// if no multiple bundles
+	// => shortened = bundle.bundles[0] , BUT without plugins markup
 	var shortened = bundleNames.map(function(l){
 		return filename(l);
 	}).join('-');
 
+	// if multiple bundles and very long concatenated name
 	if (bundle.bundles.length > 1 && shortened.length > 25) {
 		var hasher = crypto.createHash("md5");
 		hasher.update(shortened);
 		var shortenedHash = hasher.digest('hex');
 		shortened = shortened.substr(0, 16) + "-" + shortenedHash.substr(0, 8);
-	}
 
-	// If this is a "main" bundle
-	if (bundle.bundles.length === 1 ) {
+		// If this is a "main" bundle
+	} else if (bundle.bundles.length === 1 ) {
 		// Use the full path name, removing trailing ".js"
-		shortened = bundle.bundles[0].replace(".js", "");
+		shortened = bundleNames[0];
 
 		var plugin = pluginPart(shortened);
 		if(plugin) {
 			shortened = pluginResource(shortened);
-			// This is a project using directories.lib
-			// and needs to be packageName/modulePath
+			// for the shortened we only want the path of the project
 			if(isNpm(shortened)) {
-				var pkgName = shortened.substr(0, shortened.indexOf("@"));
-				shortened = pkgName + "/" + deNpm(shortened);
+				shortened = deNpm(shortened)['path'];
 			}
-			shortened = shortened.substr(0, shortened.indexOf("."));
+
+			// e.g. index.stache
+			if(shortened.indexOf(".") !== -1){
+				shortened = shortened.substr(0, shortened.indexOf("."));
+			}
 		}
 	}
 
+	// if the first bundle is a project module
+	// using directories.lib
+	// so dirName needs to be packageName/modulePath
+	if(isNpm(bundleNames[0])) {
+		dirName += deNpm(bundleNames[0])["package"] + "/";
+	}
+
 	var buildType = bundle.buildType || "js",
-		buildTypeSuffix = buildType === "js" ? "" : "."+buildType+"!";
+			buildTypeSuffix = buildType === "js" ? "" : "."+buildType+"!";
+
+	// delete the String prototype method
+	delete String.prototype.removeTrailing;
 
 	if(!usedBundleNames[shortened]){
 		usedBundleNames[shortened] = true;
-		return dirName+deNpm(shortened+buildTypeSuffix);
+		return dirName+deNpm(shortened+buildTypeSuffix)["path"];
 	} else if(shortened.length > 50){
 		return dirName+shortened.substr(0,50)+"-"+bundleNames.length+"-"+(bundleCounter++)+buildTypeSuffix;
 	} else {

--- a/lib/bundle/name.js
+++ b/lib/bundle/name.js
@@ -1,11 +1,10 @@
-var crypto = require('crypto'),
-	_ = require('lodash'),
-	winston = require('winston');
+var crypto = require('crypto');
 
 var npmNameExp = /.+@.+#.+/;
 /**
  * is a npm module name?
  * do not support npm scoping!
+ *
  * @param name
  * @returns {boolean}
  */
@@ -16,19 +15,34 @@ function isNpm(name) {
 /**
  * get the path of a npm module
  * {packagename}@{version}#{path}
+ *
  * @param name
- * @returns {*}
+ * @returns {{package: string, version: string, path: string}}
  */
 function deNpm(name) {
 	var modulePackage = name.substr(0, name.indexOf("@"));
 	var moduleVersion = name.substring(name.indexOf("@")+1, name.indexOf("#"));
-	var modulePath = name.substr(name.indexOf("#")+1);
+	var modulePath = removeFiletype(name.substr(name.indexOf("#")+1));
+
 	return {
 		'package': modulePackage,
 		'version': moduleVersion,
 		'path': modulePath
 	};
 }
+
+/**
+ * remove the filetype from a
+ *
+ * @param modulePath
+ * @returns {*}
+ */
+var removeFiletype = function(modulePath) {
+	if(modulePath.lastIndexOf('.') !== -1) {
+		modulePath = modulePath.substr(0, modulePath.lastIndexOf('.'));
+	}
+	return modulePath;
+};
 
 /**
  * get the last part of a module path
@@ -40,35 +54,66 @@ function deNpm(name) {
  * @param uri
  * @returns {string}
  */
-var filename = function(uri){
-		var lastSlash = uri.lastIndexOf("/");
-		var sub;
-		if(lastSlash == -1) {
-			sub = uri;
-		} else {
-			sub = uri.substr(lastSlash + 1);
-		}
-		var matches = deNpm(sub).path.match(/^[\w-\s\.]+/);
-		return matches ? matches[0] : "";
-	},
-	pluginPart = function(name){
-		var bang = name.lastIndexOf("!");
-		if(bang !== -1) {
-			return name.substr(bang+1);
-		}
-	},
-	pluginResource = function(name){
-		var bang = name.lastIndexOf("!");
-		if(bang !== -1) {
-			return name.substr(0, bang);
-		}
-	};
+var filename = function (uri) {
+	var lastSlash = uri.lastIndexOf("/");
+	var sub;
+	if (lastSlash == -1) {
+		sub = uri;
+	} else {
+		sub = uri.substr(lastSlash + 1);
+	}
+	var matches = deNpm(sub.toLowerCase()).path.match(/^[\w-\s\.]+/);
+	return matches ? matches[0] : "";
+};
+
+/**
+ * return the plugin part
+ *
+ * @param name
+ * @returns {string}
+ */
+var pluginPart = function (name) {
+	var bang = name.lastIndexOf("!");
+	if (bang !== -1) {
+		return name.substr(bang + 1);
+	}
+};
+
+/**
+ * return the plugin resource
+ *
+ * @param name
+ * @returns {string}
+ */
+var pluginResource = function (name) {
+	var bang = name.lastIndexOf("!");
+	if (bang !== -1) {
+		return name.substr(0, bang);
+	}
+};
+
+/**
+ * get a unique name, based on bundleCounter
+ *
+ * @param dirName
+ * @param shortened
+ * @param buildTypeSuffix
+ * @returns {string}
+ */
+var getUniqueName = function (dirName, shortened, buildTypeSuffix) {
+	if (!usedBundleNames[dirName + shortened + buildTypeSuffix]) {
+		return dirName + shortened + buildTypeSuffix + "";
+	}else {
+		return dirName + shortened + "-" + (bundleCounter++) + buildTypeSuffix + "";
+	}
+};
 
 var bundleCounter = 0;
 var usedBundleNames = {};
 
 /**
  * get the name of a bundle
+ *
  * @param bundle
  * @returns {string}
  */
@@ -76,73 +121,69 @@ function getName(bundle) {
 
 	/**
 	 * add a prototype method to String
+	 *
 	 * @param whatever
 	 * @returns {string}
 	 */
-	String.prototype.removeTrailing = function (whatever) {
-		var result = this;
-		if(this.substr((-1 * whatever.length)) === whatever) {
-			result = this.substr(0, this.length - (1 * whatever.length));
-		}
-		return result+"";
-	};
+	if(!String.prototype.removeTrailing) {
+		String.prototype.removeTrailing = function (whatever) {
+			var result = this;
+			if (this.substr((-1 * whatever.length)) === whatever) {
+				result = this.substr(0, this.length - (1 * whatever.length));
+			}
+			return result + "";
+		};
+	}
 
-	var dirName = "bundles/";
+	var bundleName,
+			dirName = "bundles/";
 
-	// remove trailing parts we do not need
-	var packages = [];
+	// remove trailing and leading parts
 	var bundleNames = bundle.bundles.map(function(appName){
-		appName = appName.removeTrailing('/').removeTrailing('.js');
-		packages.push(deNpm(appName).package);
+		appName = appName.trim().removeTrailing('/');
 		return appName;
 	});
-	packages = _.uniq(packages);
 
-	if(packages.length > 1) {
-		winston.warn("There is two or more different package names inside the bundles array." +
-			"The destination folder is set to "+dirName+'/'+packages.shift());
-	}
-
-	// concat multiple bundles into one shortened filename,
-	// for that use only the last part of each modulepath
-	// if no multiple bundles
-	// => shortened = bundle.bundles[0] , BUT without plugins markup
-	var shortened = bundleNames.map(function(l){
-		return filename(l);
-	}).join('-');
-
-	// if multiple bundles and very long concatenated name
-	if (bundle.bundles.length > 1 && shortened.length > 25) {
-		var hasher = crypto.createHash("md5");
-		hasher.update(shortened);
-		var shortenedHash = hasher.digest('hex');
-		shortened = shortened.substr(0, 16) + "-" + shortenedHash.substr(0, 8);
-
-		// If this is a "main" bundle
-	} else if (bundle.bundles.length === 1 ) {
-		// Use the full path name, removing trailing ".js"
+	// If this is a "main" bundle
+	if (bundle.bundles.length === 1) {
+		// main module
 		shortened = bundleNames[0];
 
-		var plugin = pluginPart(shortened);
-		if(plugin) {
+		if(pluginPart(shortened)) {
 			shortened = pluginResource(shortened);
-			// for the shortened we only want the path of the project
-			if(isNpm(shortened)) {
-				shortened = deNpm(shortened).path;
-			}
-
-			// e.g. index.stache
-			if(shortened.indexOf(".") !== -1){
-				shortened = shortened.substr(0, shortened.indexOf("."));
-			}
 		}
-	}
 
-	// if the first bundle is a project module
-	// using directories.lib
-	// so dirName needs to be packageName/modulePath
-	if(isNpm(bundleNames[0])) {
-		dirName += deNpm(bundleNames[0]).package + "/";
+		// for the shortened we only want the path of the module
+		if(isNpm(shortened)) {
+			var module = deNpm(shortened);
+			shortened = module.path;
+			dirName += module.package + "/";
+
+			// no npm module !
+		}else{
+			shortened = removeFiletype(shortened);
+		}
+
+		// if multiple bundles and very long concatenated name
+	} else if (bundle.bundles.length > 1) {
+
+		// concat multiple bundles into one shortened filename,
+		// for that use only the last part of each modulepath
+		var shortened = bundleNames.map(function(l){
+			return filename(l);
+		}).join('-');
+
+		// we dont care about naming rules
+		// we add the bundles into the bundles config
+		shortened = shortened.replace(/[^\w\-_]/g, "-").replace(/-{2,}/g, '-');
+
+		if(shortened.length > 25) {
+			var hasher = crypto.createHash("md5");
+			hasher.update(shortened);
+			var shortenedHash = hasher.digest('hex');
+			shortened = shortened.substr(0, 16) + "-" + shortenedHash.substr(0, 8);
+		}
+
 	}
 
 	var buildType = bundle.buildType || "js",
@@ -151,18 +192,27 @@ function getName(bundle) {
 	// delete the String prototype method
 	delete String.prototype.removeTrailing;
 
-	if(!usedBundleNames[shortened]){
-		usedBundleNames[shortened] = true;
-		return dirName+deNpm(shortened+buildTypeSuffix).path;
-	} else if(shortened.length > 50){
-		return dirName+shortened.substr(0,50)+"-"+bundleNames.length+"-"+(bundleCounter++)+buildTypeSuffix;
+
+	if(bundle.bundles.length === 1) {
+		// we dont want do rewrite a main module
+		bundleName = dirName + shortened + buildTypeSuffix;
+
 	} else {
-		return dirName+shortened+buildTypeSuffix;
+		bundleName = getUniqueName(dirName, shortened, buildTypeSuffix);
 	}
+
+	usedBundleNames[bundleName] = true;
+
+	return bundleName;
 }
 
 exports = module.exports = function(bundle) {
 	bundle.name = getName(bundle);
+};
+
+exports.clearBundleCounter = function() {
+	usedBundleNames = [];
+	bundleCounter = 0;
 };
 
 exports.getName = getName;

--- a/lib/bundle/name.js
+++ b/lib/bundle/name.js
@@ -216,4 +216,6 @@ exports.clearBundleCounter = function() {
 	bundleCounter = 0;
 };
 
+exports.bundleCounter = bundleCounter;
+
 exports.getName = getName;

--- a/lib/stream/build.js
+++ b/lib/stream/build.js
@@ -129,6 +129,11 @@ module.exports = function(){
 		// Combine all bundles
 		var allBundles = splitMainBundles.concat(splitBundles);
 		allBundles = allBundles.concat.apply(allBundles, unbundledBundles);
+
+		// in each multibuild we will start from beginning.
+		// with that, it is possible now, that file collisions are present
+		// in different multibuilds
+		nameBundle.clearBundleCounter();
 		// Name each bundle so we know what to call the bundle.
 		allBundles.forEach(nameBundle);
 

--- a/lib/stream/bundle.js
+++ b/lib/stream/bundle.js
@@ -99,6 +99,11 @@ function bundle(data){
 	// Combine all bundles
 	var allBundles = splitMainBundles.concat(splitBundles);
 	allBundles = allBundles.concat.apply(allBundles, unbundledBundles);
+
+	// in each multibuild we will start from beginning.
+	// with that, it is possible now, that file collisions are present
+	// in different multibuilds
+	nameBundle.clearBundleCounter();
 	// Name each bundle so we know what to call the bundle.
 	allBundles.forEach(nameBundle);
 

--- a/test/bundle_name_test.js
+++ b/test/bundle_name_test.js
@@ -1,0 +1,184 @@
+var assert = require("assert"),
+	crypto = require('crypto'),
+	winston = require('winston'),
+	nameBundle = require("../lib/bundle/name");
+
+var dirName = "bundles/";
+
+describe("bundle name without npm package", function() {
+	beforeEach(function () {
+	});
+
+	it("works with just a normal modulename", function () {
+		var bundle = {
+			bundles: ["main"]
+		};
+		var bundleName = nameBundle.getName(bundle);
+		assert.equal(bundleName, dirName + 'main');
+	});
+
+	it("remove trailing parts", function () {
+		var bundleName = nameBundle.getName({bundles: ["main.js"]});
+		assert.equal(bundleName, dirName + 'main');
+
+		bundleName = nameBundle.getName({bundles: ["main/"]});
+		assert.equal(bundleName, dirName + 'main');
+
+		//bundleName = nameBundle.getName({bundles: ["foo@1.0.0#bar/"]});
+		//assert.equal(bundleName, dirName + 'bar');
+
+	});
+
+	it("works with multiple bundles", function(){
+		var bundle = {
+			bundles: ["main/bar", "bar/foo"]
+		};
+		var bundleName = nameBundle.getName(bundle);
+		assert.equal(bundleName, dirName + 'bar-foo');
+
+		bundle = {
+			bundles: ["main/bar", "bar/foo"],
+			buildType: "txt"
+		};
+		bundleName = nameBundle.getName(bundle);
+		assert.equal(bundleName, dirName + 'bar-foo.txt!');
+	});
+
+	it("works if buildType is a extension", function(){
+		var bundle = {
+			bundles: ["main"],
+			buildType: "txt"
+		};
+		nameBundle(bundle);
+		assert.equal(bundle.buildType, 'txt');
+		assert.equal(bundle.name, dirName + 'main.txt!');
+	});
+
+	it("with very long name", function(){
+		var count = 0;
+
+		var bundle = {
+			bundles: ["deep/folder/structure/with/very/very-very-long-name"]
+		};
+		var bundleName = nameBundle.getName(bundle);
+		assert.equal(bundleName, dirName + 'deep/folder/structure/with/very/very-very-long-name');
+
+		// again...
+		bundleName = nameBundle.getName(bundle);
+		assert.equal(bundleName, dirName + 'deep/folder/structure/with/very/very-very-long-nam-1-' + (count++));
+
+		bundle = {
+			bundles: ["main/my-very-long-name", "bar/eman-gnol-yrev-ym"]
+		};
+		bundleName = nameBundle.getName(bundle);
+		assert.equal(bundleName, dirName + 'my-very-long-nam-34e05993');
+
+
+		bundle = {
+			bundles: ["deep/folder/structure/with/very/very/very-long-name"],
+			buildType: "txt"
+		};
+		nameBundle(bundle);
+		assert.equal(bundle.buildType, 'txt');
+		assert.equal(bundle.name, dirName + 'deep/folder/structure/with/very/very/very-long-name.txt!');
+
+		// again...
+		nameBundle(bundle);
+		assert.equal(bundle.name, dirName + 'deep/folder/structure/with/very/very/very-long-nam-1-'+ (count++) +'.txt!');
+
+	});
+
+	it("works with a plugin markup", function() {
+		var bundle = {
+			bundles: ["index.stache!done-autorender"]
+		};
+		var bundleName = nameBundle.getName(bundle);
+		assert.equal(bundleName, dirName + 'index');
+
+		bundle = {
+			bundles: ["main!my-plugin"]
+		};
+		bundleName = nameBundle.getName(bundle);
+		assert.equal(bundleName, dirName + 'main');
+	});
+
+});
+
+describe("bundle name with npm package", function() {
+	var oldWinstonWarning,
+		warns;
+	beforeEach(function () {
+		oldWinstonWarning = winston.warn;
+		warns = [];
+
+		winston.warn = function(msg){
+			warns.push(msg);
+		};
+	});
+
+	afterEach(function(){
+		winston.warn = oldWinstonWarning;
+	});
+
+	it("works for a package module", function(){
+		var bundle = {
+			bundles: ["foo@1.0.0#bar"]
+		};
+		var bundleName = nameBundle.getName(bundle);
+		assert.equal(bundleName, dirName + 'foo/bar');
+	});
+
+	it("works with multiple bundles", function(){
+		var bundle = {
+			bundles: ["foo@1.0.0#component/my-component", "foo@1.0.0#foo"]
+		};
+		var bundleName = nameBundle.getName(bundle);
+		assert.equal(bundleName, dirName + 'foo/my-component-foo');
+	});
+
+	it("remove trailing parts", function () {
+		var bundle = {
+			bundles: ["foo@1.0.0#main/bar/", "foo@1.0.0#foo.js"]
+		};
+		var bundleName = nameBundle.getName(bundle);
+		assert.equal(bundleName, dirName + 'foo/bar-foo');
+	});
+
+	it("works with a plugin markup", function(){
+
+		var bundle = {
+			bundles: ["mypkg@1.0.0#index.stache!done-autorender"]
+		};
+		var bundleName = nameBundle.getName(bundle);
+		assert.equal(bundleName, dirName + 'mypkg/index');
+
+		bundle = {
+			bundles: ["mypkg@1.0.0#main!my-plugin"]
+		};
+		bundleName = nameBundle.getName(bundle);
+		assert.equal(bundleName, dirName + 'mypkg/main');
+	});
+
+	it("should show a warning if one of the bundles is not npm like", function(){
+		var bundle = {
+			bundles: ["foo@1.0.0#main", "main"]
+		};
+		var bundleName = nameBundle.getName(bundle);
+		assert.equal(bundleName, dirName + 'foo/main-main');
+		// check warning
+		assert.equal(warns.pop(), "There is two or more different package names inside the bundles array." +
+			"The destination folder is set to "+dirName+"/foo");
+	});
+
+	it("should show a warning if in bundles array are two or more diffrent package names", function(){
+		var bundle = {
+			bundles: ["mypkg@1.0.0#main", "jquery@1.0.0#lib/index"]
+		};
+		var bundleName = nameBundle.getName(bundle);
+		assert.equal(bundleName, dirName + 'mypkg/main-index');
+		// check warning
+		assert.equal(warns.pop(), "There is two or more different package names inside the bundles array." +
+			"The destination folder is set to "+dirName+"/mypkg");
+	});
+
+});

--- a/test/export_test.js
+++ b/test/export_test.js
@@ -449,7 +449,7 @@ describe("export", function(){
 		});
 	});
 
-	describe("Source Maps", function(){
+	describe.only("Source Maps", function(){
 		this.timeout(5000);
 
 		beforeEach(function(done){
@@ -491,7 +491,7 @@ describe("export", function(){
 
 		function verify() {
 			var globalJsMap = read("global/tabs.js.map");
-			assert.equal(globalJsMap.sources[1], path.join("..","..","src/tabs.js"), "Relative to source file");
+			assert.equal(globalJsMap.sources[1], path.join("..","..","..","src/tabs.js"), "Relative to source file");
 			assert.equal(globalJsMap.file, "tabs.js", "Refers to generated file");
 
 			var globalJs = read("global/tabs.js");

--- a/test/export_test.js
+++ b/test/export_test.js
@@ -449,7 +449,7 @@ describe("export", function(){
 		});
 	});
 
-	describe.only("Source Maps", function(){
+	describe("Source Maps", function(){
 		this.timeout(5000);
 
 		beforeEach(function(done){

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -1552,26 +1552,25 @@ describe("multi build", function(){
 					fs.copy(path.join(__dirname, "..", "node_modules","jquery"),
 						path.join(__dirname, "npm", "node_modules", "jquery"), function(error){
 
-						//if(error){ return done(error); }
-						//
-						//fs.copy(
-						//	path.join(__dirname, "..", "bower_components","steal"),
-						//	path.join(__dirname, "npm", "node_modules", "steal"), function(error){
-						//
-						//	if(error){ return done(error); }
-						//
-						//	fs.copy(
-						//		path.join(__dirname, "..", "bower_components","steal"),
-						//		__dirname+"/npm/node_modules/steal", function(error){
-						//
-						//		if(error){ return done(error); }
-						//
-						//		done()
-						//
-						//	});
-							done()
+						if(error){ return done(error); }
 
-						//});
+						fs.copy(
+							path.join(__dirname, "..", "bower_components","steal"),
+							path.join(__dirname, "npm", "node_modules", "steal"), function(error){
+
+							if(error){ return done(error); }
+
+							fs.copy(
+								path.join(__dirname, "..", "bower_components","steal"),
+								__dirname+"/npm/node_modules/steal", function(error){
+
+								if(error){ return done(error); }
+
+								done()
+
+							});
+
+						});
 					});
 				});
 			});

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -1523,7 +1523,7 @@ describe("multi build", function(){
 				done();
 			});
 
-			sharedBundleName = __dirname+"/npm-directories/dist/bundles/npm-dependencies" +
+			sharedBundleName = __dirname+"/npm-directories/dist/bundles/npm-dependencies/" +
 				"main.js";
 
 			fs.exists(sharedBundleName, function(exists){

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -1518,18 +1518,19 @@ describe("multi build", function(){
 			var sharedBundleName = __dirname+"/npm-directories/dist/bundles/" +
 				"category-home.js";
 
-			fs.exists(sharedBundleName, function(exists){
-				assert.ok(exists, "shared bundle name was created in the right folder");
-				done();
-			});
-
-			sharedBundleName = __dirname+"/npm-directories/dist/bundles/npm-dependencies/" +
+			var mainBundleName = __dirname+"/npm-directories/dist/bundles/npm-dependencies/" +
 				"main.js";
 
 			fs.exists(sharedBundleName, function(exists){
-				assert.ok(exists, "main bundle was created in the package folder");
-				done();
+				assert.ok(exists, "shared bundle name was created in the right folder");
+
+				fs.exists(mainBundleName, function(exists){
+					assert.ok(exists, "main bundle was created in the package folder");
+					done();
+				});
+
 			});
+
 		});
 	});
 
@@ -1551,25 +1552,26 @@ describe("multi build", function(){
 					fs.copy(path.join(__dirname, "..", "node_modules","jquery"),
 						path.join(__dirname, "npm", "node_modules", "jquery"), function(error){
 
-						if(error){ return done(error); }
+						//if(error){ return done(error); }
+						//
+						//fs.copy(
+						//	path.join(__dirname, "..", "bower_components","steal"),
+						//	path.join(__dirname, "npm", "node_modules", "steal"), function(error){
+						//
+						//	if(error){ return done(error); }
+						//
+						//	fs.copy(
+						//		path.join(__dirname, "..", "bower_components","steal"),
+						//		__dirname+"/npm/node_modules/steal", function(error){
+						//
+						//		if(error){ return done(error); }
+						//
+						//		done()
+						//
+						//	});
+							done()
 
-						fs.copy(
-							path.join(__dirname, "..", "bower_components","steal"),
-							path.join(__dirname, "npm", "node_modules", "steal"), function(error){
-
-							if(error){ return done(error); }
-
-							fs.copy(
-								path.join(__dirname, "..", "bower_components","steal"),
-								__dirname+"/npm/node_modules/steal", function(error){
-
-								if(error){ return done(error); }
-
-								done()
-
-							});
-
-						});
+						//});
 					});
 				});
 			});
@@ -1638,7 +1640,7 @@ describe("multi build", function(){
 					minify: false
 				}).then(function(){
 					// Make sure they are named correctly.
-					assert(fs.existsSync(__dirname + "/npm/dist/bundles/two.js"),
+					assert(fs.existsSync(__dirname + "/npm/dist/bundles/npm-test/two.js"),
 										 "two bundle in the right place");
 
 					// open the prod page and make sure

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -1509,7 +1509,7 @@ describe("multi build", function(){
 				}, {
 					quiet: true
 				});
-			}).then(function(){
+			}).then(function(buildResult){
 				done();
 			}, done);
 		});
@@ -1517,8 +1517,17 @@ describe("multi build", function(){
 		it("creates pretty shared bundle names", function(done){
 			var sharedBundleName = __dirname+"/npm-directories/dist/bundles/" +
 				"category-home.js";
+
 			fs.exists(sharedBundleName, function(exists){
-				assert.ok(exists, "shared bundle name was created");
+				assert.ok(exists, "shared bundle name was created in the right folder");
+				done();
+			});
+
+			sharedBundleName = __dirname+"/npm-directories/dist/bundles/npm-dependencies" +
+				"main.js";
+
+			fs.exists(sharedBundleName, function(exists){
+				assert.ok(exists, "main bundle was created in the package folder");
 				done();
 			});
 		});

--- a/test/npm-directories/prod.html
+++ b/test/npm-directories/prod.html
@@ -1,4 +1,4 @@
-<script src="../../bower_components/steal/steal.js"
+<script src="../../node_modules/steal/steal.js"
 	env="production"
 	data-config="./package.json!npm"
 	main="npm-dependencies/main.txt!npm-dependencies/plug"></script>

--- a/test/npm/prod-bundle.html
+++ b/test/npm/prod-bundle.html
@@ -2,5 +2,5 @@
 <body>
 	<script src="./node_modules/steal/steal.js"
 		data-env="production"
-		data-main="main"></script>
+		data-main="npm-test/main"></script>
 </body>

--- a/test/npm/prod-bundled.html
+++ b/test/npm/prod-bundled.html
@@ -1,4 +1,4 @@
 <body>
-	<script src="dist/bundles/main.js"></script>
+	<script src="dist/bundles/npm-test/main.js"></script>
 </body>
 

--- a/test/npm/prod.html
+++ b/test/npm/prod.html
@@ -1,6 +1,6 @@
 <body>
 	<script src='./node_modules/steal/steal.js'
 		data-env="production"
-		data-main="main"></script>
+		data-main="npm-test/main"></script>
 </body>
 

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,7 @@ if(typeof Symbol !== "undefined") {
 	require("./test_live");
 }
 
+require("./bundle_name_test");
 require("./dependencygraph_test");
 require("./bundle_test");
 require("./order_test");


### PR DESCRIPTION
renaming bundles if npm package is provided.

the problem is, if using package.json, there is this `System.directories.lib` (usually `src`). this works great in development mode
```
<script 
	src="node_modules/steal/steal.js"
	env="window-development"
	main="mypkg/main"
></script>
```
-> file will load from `/src/main.js"

but in production mode it would fail with the old naming behaviour.
-> tried to load file from `/dist/bundles/mypkg/main.js`
but if we have this simple build:
**package.json**
```
..
"system": {
    "main": "app_a"
}
...
```

**build.js**
```
var s = require("steal-tools").streams;

var graphStream = s.graph({
	config: __dirname + "/package.json!npm",
});

var stream = graphStream
.pipe(s.transpile())
.pipe(s.minify())
.pipe(s.bundle())
.pipe(s.concat())
.pipe(s.write());
```
the file is located at `/dist/bundles/main.js`

---

with the new naming, a bundle like `mypkg@1.0.0#main`is now located at `/dist/bundles/mypkg/main.js`

add tests for nameing bundles with and without npm packages