### PR TITLE
Show message when live-reload port is being used

### DIFF
--- a/lib/create_websocket_server.js
+++ b/lib/create_websocket_server.js
@@ -3,12 +3,25 @@ var http = require("http");
 
 module.exports = function(options){
 	var port = options.liveReloadPort || 8012;
-	var server = http.createServer().listen(port);
-	
-	var wss = new WebSocketServer({ server: server });
-	wss.on("connection", function(){
-		console.error("Received client connection");
-	});
 
-	return wss;
+	return new Promise(function(resolve, reject){
+		var server = http.createServer().listen(port);
+
+		server.on("listening", function(){
+			var wss = new WebSocketServer({ server: server });
+			wss.on("connection", function(){
+				console.error("Received client connection");
+			});
+
+			resolve(wss);
+		});
+
+		server.on("error", function(err){
+			if(err.errno === "EADDRINUSE") {
+				console.error("Can not start live-reload on port " + port +
+					".\nAnother application is already using it.");
+			}
+			reject(err);
+		});
+	});
 };

--- a/lib/stream/live.js
+++ b/lib/stream/live.js
@@ -25,51 +25,54 @@ module.exports = function(config, options){
 	initialGraphStream.pipe(graphStream);
 
 	// Setup the websocket connection.
-	var wss = createServer(options);
-	var port = wss.options.server.address().port;
+	createServer(options).then(function(wss){
+		var port = wss.options.server.address().port;
 
-	wss.on("connection", function(ws){
-		// Get the initial graph for this main,
-		// if it's not already part of the graph.
-		ws.once("message", function(moduleName){
-			graphPromise.then(function(){
-				graphStream.write(moduleName);
+		wss.on("connection", function(ws){
+			// Get the initial graph for this main,
+			// if it's not already part of the graph.
+			ws.once("message", function(moduleName){
+				graphPromise.then(function(){
+					graphStream.write(moduleName);
+				});
 			});
 		});
-	});
 
-	var watchStream = watch(graphStream);
-	watchStream.on("data", onChange);
+		var watchStream = watch(graphStream);
+		watchStream.on("data", onChange);
 
-	function onChange(node) {
-		var moduleName = node ? node.load.name : "";
+		function onChange(node) {
+			var moduleName = node ? node.load.name : "";
 
-		if(moduleName) {
-			console.error("Reloading", moduleName.green);
+			if(moduleName) {
+				console.error("Reloading", moduleName.green);
 
-			// Alert all clients of the change
-			wss.clients.forEach(function(ws){
-				ws.send(moduleName);
-			});
+				// Alert all clients of the change
+				wss.clients.forEach(function(ws){
+					ws.send(moduleName);
+				});
+			}
+
+			// Update our dependency graph
+			graphStream.write(moduleName);
 		}
 
-		// Update our dependency graph
-		graphStream.write(moduleName);
-	}
+		graphStream.once("data", function(){
+			console.error("Live-reload server listening on port", port);
+		});
 
-	graphStream.once("data", function(){
-		console.error("Live-reload server listening on port", port);
+		graphStream.on("error", function(err){
+			if(err.moduleName) {
+				console.error("Oops! Error reloading", err.moduleName.red);
+			} else {
+				console.error(err);
+			}
+		});
+
+		initialGraphStream.write(config.main);
+	}, function(){
+		process.exit(1);
 	});
-
-	graphStream.on("error", function(err){
-		if(err.moduleName) {
-			console.error("Oops! Error reloading", err.moduleName.red);
-		} else {
-			console.error(err);
-		}
-	});
-
-	initialGraphStream.write(config.main);
 
 	return graphStream;
 };


### PR DESCRIPTION
Wait until the http server is listening before starting the web socket server and if the http server fails to load (because the port is in use), let the user know and kill the process.

Closes #364