### PR TITLE
Add test for makeBundlesConfig

### DIFF
--- a/lib/bundle/bundle_test.js
+++ b/lib/bundle/bundle_test.js
@@ -1,0 +1,77 @@
+var assert = require("assert");
+var makeBundlesConfig = require("./make_bundles_config");
+var makeBundleNameMap = require("./make_bundle_name_map");
+
+describe("lib/bundle", function(){
+	describe("makeBundlesConfig", function(){
+		describe("bundleSteal", function(){
+			it("Adds config for a shared bundle", function(){
+				var bundles = [
+					{ name: "bundles/a" },
+					{ name: "bundles/b" },
+					{ name: "bundles/a-b", nodes: [
+						{ load: { name: "one" } },
+						{ load: { name: "two" } }
+					] }
+				];
+				var target = bundles[0];
+				var configuration = {
+					loader: {},
+					options: {
+						bundleSteal: true
+					}
+				};
+				var options = {
+					excludedBundles: makeBundleNameMap(
+						bundles.slice(0, 2)
+					)
+				};
+
+				var node = makeBundlesConfig(bundles, configuration,
+											 target, options);
+
+				var bundlesConfig = node.load.metadata.bundlesConfig;
+
+				var shared = bundlesConfig["bundles/a-b"];
+				assert(shared, "shared bundle is part of the config");
+
+				assert.equal(shared.indexOf("one"), 0, "added the first node");
+				assert.equal(shared.indexOf("two"), 1, "added the second node");
+			});
+
+			it("Works no matter how the bundles are ordered", function(){
+				var bundles = [
+					{ name: "bundles/a-b", nodes: [
+						{ load: { name: "one" } },
+						{ load: { name: "two" } }
+					] },
+					{ name: "bundles/a" },
+					{ name: "bundles/b" },
+				];
+				var target = bundles[1];
+				var configuration = {
+					loader: {},
+					options: {
+						bundleSteal: true
+					}
+				};
+				var options = {
+					excludedBundles: makeBundleNameMap(
+						bundles.slice(1)
+					)
+				};
+
+				var node = makeBundlesConfig(bundles, configuration,
+											 target, options);
+
+				var bundlesConfig = node.load.metadata.bundlesConfig;
+
+				var shared = bundlesConfig["bundles/a-b"];
+				assert(shared, "shared bundle is part of the config");
+
+				assert.equal(shared.indexOf("one"), 0, "added the first node");
+				assert.equal(shared.indexOf("two"), 1, "added the second node");
+			});
+		});
+	});
+});

--- a/lib/bundle/make_bundle_name_map.js
+++ b/lib/bundle/make_bundle_name_map.js
@@ -1,0 +1,10 @@
+
+module.exports = function(bundles){
+	var map = {};
+
+	bundles.forEach(function(bundle){
+		map[bundle.name] = true;
+	});
+
+	return map;
+};

--- a/lib/bundle/make_bundles_config.js
+++ b/lib/bundle/make_bundles_config.js
@@ -12,9 +12,6 @@ module.exports = function(bundles, configuration, targetBundle, options){
 	var excludedBundles = options.excludedBundles || {};
 
 	var bundledBundles = bundles.slice(0);
-	if(configuration.options.bundleSteal){
-		bundledBundles.shift();
-	}
 
 	var bundlesConfig = {};
 	bundledBundles.forEach(function(bundle){
@@ -28,7 +25,12 @@ module.exports = function(bundles, configuration, targetBundle, options){
 	});
 
 	return {
-		load: {name: "[system-bundles-config]"},
+		load: {
+			name: "[system-bundles-config]",
+			metadata: {
+				bundlesConfig: bundlesConfig
+			}
+		},
 		minifiedSource: paths + "System.bundles = "+JSON.stringify(bundlesConfig)+";"
 	};
 };

--- a/lib/stream/bundle.js
+++ b/lib/stream/bundle.js
@@ -8,6 +8,7 @@ var hasES6 = require("../graph/has_es6");
 var isEmpty = require("lodash").isEmpty;
 var makeBundle = require("../bundle/make_bundle");
 var makeBundlesConfig = require("../bundle/make_bundles_config");
+var makeBundleNameMap = require("../bundle/make_bundle_name_map");
 var markBundlesDirty = require("../bundle/mark_as_dirty");
 var nameBundle = require("../bundle/name");
 var order = require("../graph/order");
@@ -104,10 +105,7 @@ function bundle(data){
 
 	// Create a lookup object of the main bundle names so that they are
 	// excluded from the Bundles config
-	var mainJSBundleNames = {};
-	mainJSBundles.forEach(function(mainJSBundle){
-		mainJSBundleNames[mainJSBundle.name] = true;
-	});
+	var mainJSBundleNames = makeBundleNameMap(mainJSBundles);
 
 	// Add @config and the bundleConfigNode to each main
 	mainJSBundles.forEach(function(mainJSBundle){

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,10 @@
 var isIOjs = process.version.substr(0, 3) !== "v0.";
 
+// Unit tests
+require("../lib/bundle/bundle_test");
+
+// Integration tests
+
 require("./test_cli");
 require("./grunt_tasks/steal_build");
 


### PR DESCRIPTION
This adds a test specifically for makeBundlesConfig. Going forward there will be a lot more unit testing happening in steal-tools. Up until now it has mostly been integration tests.