### PR TITLE
Make eval avoid closure variables

### DIFF
--- a/lib/bundle/add_global_shim.js
+++ b/lib/bundle/add_global_shim.js
@@ -9,8 +9,9 @@ module.exports = function(bundle, options){
 	var exports = options.exports; // ? exportsForDependencies(bundle.nodes, options.exports) : {};
 	var shim = fs.readFileSync(path.join(__dirname, "shim.js"));
 	var shimEnd = fs.readFileSync(path.join(__dirname, "shim-end.js"));
+	var shimEval = fs.readFileSync(path.join(__dirname, "shim-eval.js"));
 
-	var source = "(" + shim.toString() +")(" + JSON.stringify(exports) + ",window)";
+	var source = "(" + shim.toString() +")(" + JSON.stringify(exports) + ",window,"+shimEval.toString()+")";
 	var start = makeNode("[global-shim-start]", source);
 	source = "(" + shimEnd.toString() + ")();";
 	var end = makeNode("[global-shim-end]", source);
@@ -39,4 +40,3 @@ module.exports = function(bundle, options){
 	});
 	return exports;
 };*/
-

--- a/lib/bundle/shim-eval.js
+++ b/lib/bundle/shim-eval.js
@@ -1,0 +1,3 @@
+function(__$source__, __$global__) { // jshint ignore:line
+	eval("(function() { " + __$source__ + " \n }).call(__$global__);");
+}

--- a/lib/bundle/shim.js
+++ b/lib/bundle/shim.js
@@ -1,4 +1,4 @@
-function(exports, global){ // jshint ignore:line
+function(exports, global, doEval){ // jshint ignore:line
 	var origDefine = global.define;
 
 	var get = function(name){
@@ -64,7 +64,7 @@ function(exports, global){ // jshint ignore:line
 			},
 			global: global,
 			__exec: function(__load){
-				eval("(function() { " + __load.source + " \n }).call(global);");
+				doEval(__load.source, global);
 			}
 		};
 	});

--- a/test/export_test.js
+++ b/test/export_test.js
@@ -157,6 +157,40 @@ describe("export", function(){
 		}, done);
 	});
 
+	it("evaled globals do not have exports in their scope (#440)", function(done){
+
+		stealExport({
+
+			system: {
+				main: "pluginifier_builder_exports/pluginify",
+				config: __dirname+"/stealconfig.js"
+			},
+			options: {
+				quiet: true
+			},
+			"outputs": {
+				"pluginify without basics": {
+					modules: ["pluginifier_builder_exports/pluginify"],
+					dest: function(){
+						return __dirname+"/out/pluginify_exports.js"
+					},
+					minify: false,
+					format: "global"
+				}
+			}
+		}).then(function(){
+			open("test/pluginifier_builder_exports/index.html", function(browser, close){
+
+				find(browser,"RESULT", function(result){
+					assert.equal(result.name, "pluginified");
+					close();
+				}, close);
+
+			}, done);
+
+		}, done);
+	});
+
 	describe("eachModule", function(){
 		it("works", function(done){
 			stealExport({
@@ -506,4 +540,3 @@ describe("export", function(){
 
 	});
 });
-

--- a/test/pluginifier_builder_exports/index.html
+++ b/test/pluginifier_builder_exports/index.html
@@ -1,0 +1,2 @@
+
+<script src="../out/pluginify_exports.js"></script>

--- a/test/pluginifier_builder_exports/pluginify.js
+++ b/test/pluginifier_builder_exports/pluginify.js
@@ -1,0 +1,5 @@
+if(typeof exports === "undefined") {
+	window.RESULT = {
+		name: "pluginified"
+	};
+}


### PR DESCRIPTION
fixes #440

This does option \#3 but should only conflict with two variables now:

```
__$source__, __$global__
``` 