### PR TITLE
Fix cli support for bundlesPath

### DIFF
--- a/lib/cli/make_system.js
+++ b/lib/cli/make_system.js
@@ -12,5 +12,9 @@ module.exports = function(argv) {
 		system.main = argv.main;
 	}
 
+	if(argv.bundlesPath) {
+		system.bundlesPath = argv.bundlesPath;
+	}
+
 	return system;
 };

--- a/test/cli/cmd_build_test.js
+++ b/test/cli/cmd_build_test.js
@@ -53,4 +53,16 @@ describe("cmd build module", function() {
 
 		assert(buildArgs.options.minify);
 	});
+
+	it("bundles-path works", function(){
+		cmdBuild.handler({
+			config: "/stealconfig.js",
+			bundlesPath: "foo"
+		});
+
+		assert.deepEqual(buildArgs.system, {
+			config: "/stealconfig.js",
+			bundlesPath: "foo"
+		});
+	});
 });


### PR DESCRIPTION
make_system should copy over the bundlesPath option from `argv` if provided. Adds a test. Closes #452