### PR TITLE
Use exports to specify global exported values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ test/pluginifier_builder_helpers/browserify-out.js
 test/6to5/dist
 test/bundle_assets/dist
 test/live_reload/out.js
+test/transform_export/out.js

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ test/6to5/dist
 test/bundle_assets/dist
 test/live_reload/out.js
 test/transform_export/out.js
+test/exports_basics/out.js

--- a/doc/types/transform-options.md
+++ b/doc/types/transform-options.md
@@ -37,14 +37,26 @@ The other possible format values are "steal","amd", and "cjs".
 This is so that the script can be run standalone. Setting _noGlobalShim_ to `true` prevents adding the shim.
 Excluding the shim means it will have to be run with an AMD loader like _requirejs_.
 
-@option {Object<moduleName,String>} exports A mapping of module names to their name on the
-global object.  For example, if an output depends on jQuery, but does not include it, you
-should include:
+@option {Object<moduleName,String>} [exports] A mapping of module names to their name on the global object (such as the `window`).  For example, if an output depends on jQuery, but does not include it, you should include:
 
     transform("mywidget",{exports: {"jquery": "jQuery"}})
 
-__note__ - In future releases, 
-these values will be taken directly from [System.shim] configuration values.
+Conversely you can also use exports to set values that should be exported from your module. For example, if you have a module **foo** that exports a value like:
+
+    module.exports = "foo bar";
+
+You can specify where this module should be set on the window:
+
+    transform("mywidget", {
+      exports: {
+        "foo": "foo.bar"
+	  }
+	});
+
+Which, when the script runs will result in:
+
+    window.foo.bar === "foo bar";
+
 
 @option {Boolean} [useNormalizedDependencies=true] Use normalized dependency names instead of
 relative module names.  For example "foo/bar" will be used instead of "./bar".

--- a/lib/build/helpers/base.js
+++ b/lib/build/helpers/base.js
@@ -48,7 +48,7 @@ var baseHelper = {
 	},
 	makeHelper: function(settings){
 		var func = function(options){
-			options = extend({}, options|| {});
+			options = extend({}, options || {});
 			for(var prop in settings) {
 				options[prop] = settings[prop](options[prop]);
 			}

--- a/lib/build/helpers/helpers.js
+++ b/lib/build/helpers/helpers.js
@@ -4,5 +4,6 @@ module.exports = {
 	amd: require("./amd"),
 	cjs: require("./cjs"),
 	"global-js": g.js,
-	"global-css": g.css
+	"global-css": g.css,
+	standalone: require("./standalone")
 };

--- a/lib/build/helpers/standalone.js
+++ b/lib/build/helpers/standalone.js
@@ -1,5 +1,6 @@
 var baseHelper = require("./base");
 var globalJS = require("./global").js;
+var npmUtils = require("steal/ext/npm-utils");
 
 /**
  * @module {function} steal-tools/lib/build/helpers/standalone standalone
@@ -39,7 +40,45 @@ var standalone = {
 	},
 	dest: globalJS.dest,
 	useNormalizedDependencies: globalJS.useNormalizedDependencies,
-	normalize: globalJS.normalize,
+	//normalize: globalJS.normalize,
+	normalize: function(){
+		return function(depName, depLoad, curName, curLoad, loader){
+			if(!depLoad) {
+				return depName;
+			}
+			var name = depLoad.name;
+			var res;
+
+			var isNpmName = npmUtils.moduleName.isNpm(name);
+
+			if(!isNpmName) {
+				return name;
+			}
+
+			// Get the package name. We need this to denpm the name.
+			var defaultPackage = npmUtils.pkg.getDefault(loader);
+			var packageName = isNpmName ?
+				npmUtils.moduleName.parse(name).packageName :
+				npmUtils.pkg.name(defaultPackage);
+
+
+			// convert this to what would be the normalized name
+			name = npmUtils.moduleName.parse(depLoad.name, packageName)
+				.modulePath;
+
+			// If this is the package's main like `lodash/main` use `lodash`
+			// instead.
+			var pkg = loader.npm[packageName] || defaultPackage;
+			if(name === npmUtils.pkg.main(pkg)) {
+				res = packageName;
+			} else {
+				res = packageName + "/" + name;
+			}
+
+			return res;
+		};
+
+	},
 	ignore: function(){
 		return false;
 	}

--- a/lib/build/helpers/standalone.js
+++ b/lib/build/helpers/standalone.js
@@ -1,0 +1,48 @@
+var baseHelper = require("./base");
+var globalJS = require("./global").js;
+
+/**
+ * @module {function} steal-tools/lib/build/helpers/standalone standalone
+ * @parent steal-tools.helpers
+ *
+ * Helper that make exporting to [syntax.global] formats easier.
+ *
+ * @signature `"+standalone": { ... OVERRIDES ... }`
+ *
+ * Exports all Javascript into a single file, including all dependencies.
+ *
+ * @body
+ *
+ * ## Use
+ *
+ * Add in `+standalone` in an output name to export your project to a single
+ * file which will include NPM dependencies. This is the option you most often
+ * want when creating a build meant to be used in a script tag or jsbin, etc.
+  *
+ * ```
+ * stealTools.export({
+ *   system: {
+ *     config: __dirname+"/package.json!npm"
+ *   },
+ *   outputs: {
+ *	   "+standalone": {
+ *       dest: __dirname + "/mylib.js"
+ *	   }
+ *   }
+ * });
+ * ```
+ */
+var standalone = {
+	modules: globalJS.modules,
+	format: function(){
+		return "global";
+	},
+	dest: globalJS.dest,
+	useNormalizedDependencies: globalJS.useNormalizedDependencies,
+	normalize: globalJS.normalize,
+	ignore: function(){
+		return false;
+	}
+};
+
+module.exports = baseHelper.makeHelper(standalone);

--- a/lib/build/transform.js
+++ b/lib/build/transform.js
@@ -41,6 +41,13 @@ var transformImport = function(config, transformOptions){
 	logging.setup(transformOptions, config);
 
 	return makeGraph(config, transformOptions).then(function(data){
+		
+		return transformImport.normalizeExports(data.steal.System,
+												transformOptions)
+		.then(function(){
+			return data;
+		});
+	}).then(function(data){
 
 		var transform = function(moduleNames, options){
 			options = _.extend({
@@ -199,6 +206,22 @@ transformImport.notIgnored = function( bundle, rules ) {
 		}
 	});
 	return notIgnored;
+};
+
+transformImport.normalizeExports = function(loader, options) {
+	var exports = options.exports;
+	var main = loader.main;
+
+	var promises = Object.keys(exports).map(function(oldName){
+		return loader.normalize(oldName, main).then(function(name){
+			if(name !== oldName) {
+				exports[name] = exports[oldName];
+				delete exports[oldName];
+			}
+		});
+	});
+
+	return Promise.all(promises);
 };
 
 transformImport.matches = matches;

--- a/lib/build/transform.js
+++ b/lib/build/transform.js
@@ -18,12 +18,6 @@ var makeGraph = require("../graph/make_graph"),
 	makeConfiguration = require("../configuration/make"),
 	addSourceMapUrl = require("../bundle/add_source_map_url");
 
-var toss = function(e){
-	setTimeout(function(){
-		throw e;
-	},1);
-};
-
 var transformImport = function(config, transformOptions){
 	transformOptions = _.assign(transformOptions || {}, {
 		useNormalizedDependencies: true
@@ -151,8 +145,6 @@ var transformImport = function(config, transformOptions){
 		return transform;
 
 
-	}).catch(function(e){
-		toss(e);
 	});
 
 };

--- a/lib/bundle/shim.js
+++ b/lib/bundle/shim.js
@@ -13,6 +13,21 @@ function(exports, global, doEval){ // jshint ignore:line
 		}
 		return cur;
 	};
+	var set = function(name, val){
+		var parts = name.split("."),
+			cur = global,
+			i, part, next;
+		for(i = 0; i < parts.length - 1; i++) {
+			part = parts[i];
+			next = cur[part];
+			if(!next) {
+				next = cur[part] = {};
+			}
+			cur = next;
+		}
+		part = parts[parts.length - 1];
+		cur[part] = val;
+	};
 	var modules = (global.define && global.define.modules) ||
 		(global._define && global._define.modules) || {};
 	var ourDefine = global.define = function(moduleName, deps, callback){
@@ -50,7 +65,14 @@ function(exports, global, doEval){ // jshint ignore:line
 		global.define = ourDefine;
 
 		// Favor CJS module.exports over the return value
-		modules[moduleName] = module && module.exports ? module.exports : result;
+		result = module && module.exports ? module.exports : result;
+		modules[moduleName] = result;
+
+		// Set global exports
+		var globalExport = exports[moduleName];
+		if(globalExport && !get(globalExport)) {
+			set(globalExport, result);
+		}
 	};
 	global.define.orig = origDefine;
 	global.define.modules = modules;

--- a/lib/cli/cmd_export.js
+++ b/lib/cli/cmd_export.js
@@ -22,9 +22,17 @@ module.exports = {
 			type: "boolean",
 			describe: "Sets default +global-js and +global-css outputs"
 		},
+		standalone: {
+			type: "boolean",
+			describe: "Sets default +standalone output"
+		},
 		all: {
 			type: "boolean",
 			describe: "Sets outputs to +cjs, +amd, +global-js, and +global-css"
+		},
+		dest: {
+			type: "string",
+			describe: "Set the destination for the created file"
 		}
 	}),
 

--- a/lib/cli/make_outputs.js
+++ b/lib/cli/make_outputs.js
@@ -13,16 +13,36 @@ module.exports = function(options) {
 			"+global-js": {
 				exports: { "jquery": "jQuery" }
 			}
-		}
+		},
+		standalone: { "+standalone": {} }
 	};
+
+	var outputOptions = [ "dest" ];
 
 	var hasSetOptions = _some(_keys(outputs), function(out) {
 		return options[out];
 	});
 
+	// determines if the output is included in "all"
+	var outputAll = function(hasSetOptions, options, out){
+		return (!hasSetOptions || options.all) && out !== "standalone";
+	};
+
 	_keys(outputs).forEach(function(out) {
-		if (!hasSetOptions || options.all || options[out]) {
+		if (outputAll(hasSetOptions, options, out) || options[out]) {
 			_merge(result, outputs[out]);
+		}
+	});
+
+	// Set the options on the outputs, like `dest`
+	outputOptions.forEach(function(opt){
+		if(options[opt]) {
+			_keys(result).forEach(function(key){
+				var out = result[key];
+				
+				// Set the value
+				out[opt] = options[opt];
+			});
 		}
 	});
 

--- a/test/cli/cmd_export_test.js
+++ b/test/cli/cmd_export_test.js
@@ -1,6 +1,7 @@
 var assert = require("assert");
 var mockery = require("mockery");
 var _has = require("lodash/has");
+var _isEmpty = require("lodash/isEmpty");
 
 describe("cmd export module", function() {
 	var cmdExport;
@@ -46,6 +47,7 @@ describe("cmd export module", function() {
 		assert(_has(cmdExport.builder, "amd"), "should include amd");
 		assert(_has(cmdExport.builder, "global"), "should include global");
 		assert(_has(cmdExport.builder, "all"), "should include all");
+		assert(_has(cmdExport.builder, "standalone", "should include standalone"));
 	});
 
 	it("handler calls steal.export", function() {
@@ -58,4 +60,50 @@ describe("cmd export module", function() {
 		assert(_has(exportConfig, "options"), "should include options");
 		assert(_has(exportConfig, "outputs"), "should include outputs");
 	});
+
+	describe("standalone", function(){
+		it("flag works by itself", function() {
+			cmdExport.handler({
+				config: "/stealconfig.js",
+				standalone: true
+			});
+
+			var outputs = exportConfig.outputs;
+			var len = Object.keys(outputs).length;
+
+			assert.equal(len, 1, "There is one output");
+			assert(_has(outputs, "+standalone"), "standalone output added");
+		});
+
+		it("can take the dest", function() {
+			cmdExport.handler({
+				config: "/stealconfig.js",
+				standalone: true,
+				dest: __dirname + "/foo.js"
+			});
+
+			var opt = exportConfig.outputs["+standalone"];
+
+			assert.equal(opt.dest, __dirname + "/foo.js", "took the dest option");
+		});
+
+		it("flag works combined with others", function(){
+			cmdExport.handler({
+				config: "/stealconfig.js",
+				standalone: true,
+				amd: true
+			});
+
+			var outputs = exportConfig.outputs;
+			var len = Object.keys(outputs).length;
+
+			assert.equal(len, 2, "there are two outputs");
+			assert(_has(outputs, "+standalone"), "has standalone");
+			assert(_has(outputs, "+amd"), "has amd");
+
+			assert(_isEmpty(outputs["+standalone"]), "standalone has no options");
+			assert(_isEmpty(outputs["+amd"]), "amd has no options");
+		});
+	});
+
 });

--- a/test/export_test.js
+++ b/test/export_test.js
@@ -432,6 +432,36 @@ describe("export", function(){
 			}, done);
 		});
 
+		describe("+standalone", function(){
+			it("Works with exporting a module from a dependency", function(done){
+				this.timeout(10000);
+				stealExport({
+					system: {
+						config: __dirname+"/exports_basics/package.json!npm"
+					},
+					options: { quiet: true },
+					"outputs": {
+						"+standalone": {
+							exports: {
+								"foo": "FOO.foo"
+							},
+							dest: __dirname + "/exports_basics/out.js"
+						}
+					}
+				})
+				.then(function() {
+					open("test/exports_basics/global.html",
+						 function(browser, close) {
+						find(browser,"FOO", function(foo){
+							assert.equal(foo.foo.bar.name, "bar", "it worked");
+							close();
+						}, close);
+					}, done);
+				}, done);
+
+			});
+		});
+
 	});
 
 	describe("npm package.json builds", function(){

--- a/test/exports_basics/global.html
+++ b/test/exports_basics/global.html
@@ -1,0 +1,1 @@
+<script src="out.js"></script>

--- a/test/exports_basics/index.js
+++ b/test/exports_basics/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+	name: "index",
+	foo: require("foo")
+};

--- a/test/exports_basics/node_modules/foo/index.js
+++ b/test/exports_basics/node_modules/foo/index.js
@@ -1,3 +1,9 @@
+var other = require("./other");
+
+if(other !== "hello world") {
+	throw new Error("it didn't work");
+}
+
 module.exports = {
 	name: "foo",
 	bar: require("bar")

--- a/test/exports_basics/node_modules/foo/index.js
+++ b/test/exports_basics/node_modules/foo/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+	name: "foo",
+	bar: require("bar")
+};

--- a/test/exports_basics/node_modules/foo/node_modules/bar/index.js
+++ b/test/exports_basics/node_modules/foo/node_modules/bar/index.js
@@ -1,0 +1,1 @@
+module.exports = { name: "bar" };

--- a/test/exports_basics/node_modules/foo/node_modules/bar/package.json
+++ b/test/exports_basics/node_modules/foo/node_modules/bar/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "bar",
+	"version": "1.0.0",
+	"main": "index.js"
+}

--- a/test/exports_basics/node_modules/foo/other.js
+++ b/test/exports_basics/node_modules/foo/other.js
@@ -1,0 +1,1 @@
+module.exports = "hello world";

--- a/test/exports_basics/node_modules/foo/package.json
+++ b/test/exports_basics/node_modules/foo/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "foo",
+	"version": "1.0.0",
+	"main": "index.js",
+	"dependencies": {
+		"bar": "1.0.0"
+	}
+}

--- a/test/exports_basics/package.json
+++ b/test/exports_basics/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "app",
+	"main": "index.js",
+	"version": "1.0.0",
+	"dependencies": {
+		"foo": "1.0.0"
+	}
+}

--- a/test/transform_export/node_modules/other/main.js
+++ b/test/transform_export/node_modules/other/main.js
@@ -1,0 +1,3 @@
+window.other = {
+	thing: "other thing"
+};

--- a/test/transform_export/node_modules/other/package.json
+++ b/test/transform_export/node_modules/other/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "other",
+	"version": "1.0.0",
+	"main": "main.js"
+}

--- a/test/transform_export/package.json
+++ b/test/transform_export/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "app",
+	"version": "1.0.0",
+	"main": "main.js",
+	"dependencies": {
+		"other": "1.0.0"
+	},
+	"system": {
+		"directories": {
+			"lib": "src"
+		}
+	}
+}

--- a/test/transform_export/site.html
+++ b/test/transform_export/site.html
@@ -1,0 +1,1 @@
+<script src="out.js"></script>

--- a/test/transform_export/src/foo.js
+++ b/test/transform_export/src/foo.js
@@ -1,0 +1,1 @@
+module.exports = "foo bar";

--- a/test/transform_export/src/main.js
+++ b/test/transform_export/src/main.js
@@ -1,0 +1,7 @@
+require("./foo");
+var other = require("other");
+
+window.MODULE = {
+	other: other,
+	foo: window.foo.bar
+};


### PR DESCRIPTION
This updates transform's `exports` property so that it can be used to specify values that should be exported.

For example if you have a module **foo** that looks like:

```js
module.exports = "foo bar";
```

And you set exports:

```js
exports: {
  "foo": "foo.bar"
}
```

Then it will set it so that `window.foo.bar === "foo bar"`.