### PR TITLE
Add documentation on export.ignore

### DIFF
--- a/doc/types/export-output.md
+++ b/doc/types/export-output.md
@@ -26,7 +26,49 @@ location.
   @param {Loader} System The System loader used by Steal to load all of these modules.  All configuration
   should be available on it.
  
-@option {Array<moduleName>|Boolean} [ignore] Modules that should be ignored and not included in the output. For the [steal-tools/lib/build/helpers/global] helper providing `false` for this option will not ignore modules defined in `node_modules` as is done by default.
+@option {Array<moduleName|steal-tools.export.ignorer>|Boolean} [ignore] Modules that should be ignored and not included in the output.
+
+You can use it like:
+
+```js
+stealTools.export({
+	system: {
+		config: __dirname + "/package.json!npm"
+	},
+	options: {},
+	outputs: {
+		"+global-js": {
+			ignore: [
+				"jquery"
+			]
+		}
+	}
+})
+```
+
+Or alternatively you can provide an [steal-tools.export.ignorer] **function** that will be called with each [moduleName], giving you the opportunity to programmatically determine if a module should be ignored.
+
+```js
+stealTools.export({
+	system: {
+		config: __dirname + "/package.json!npm"
+	},
+	options: {},
+	outputs: {
+		"+global-js": {
+			ignore: [function(name){
+				if(name.indexOf("foobar") >= 0) {
+					return true;
+				} else {
+					return false;
+				}
+			}]
+		}
+	}
+})
+```
+
+For the [steal-tools/lib/build/helpers/global] helper providing `false` (instead of an Array) for this option will not ignore modules defined in `node_modules` as is done by default.
 
 @body
 

--- a/doc/types/steal-export-ignorer.md
+++ b/doc/types/steal-export-ignorer.md
@@ -1,0 +1,11 @@
+@typedef {Function} steal-tools.export.ignorer ignorer
+@parent steal-tools.export.output
+
+Specifies a function that decides of a module should be ignored (not included) in the exported artifact.
+
+@signature `ignorer(name, load)`
+
+@param {moduleName} name The module name.
+@param {load} load The load object for this module.
+
+@return {Boolean} True if this module should be ignored.


### PR DESCRIPTION
This documents export.ignore better, breaking out a typedef for the **ignorerer** function that is optional. Closes #437