### PR TITLE
Adds test to verify es/cjs interop

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 environment:
   matrix:
   # node.js
-  - nodejs_version: "5.5.0"
+  - nodejs_version: "5.8.0"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "grunt-release": "^0.7.0",
     "grunt-simple-mocha": "^0.4.0",
     "istanbul": "^0.4.2",
-    "jquery": ">2.0",
+    "jquery": "^2.0.0",
     "mocha": "^2.2.5",
     "mocha-lcov-reporter": "^1.2.0",
     "mock-fs": "^3.1.0",

--- a/test/es_cjs/dev.html
+++ b/test/es_cjs/dev.html
@@ -1,0 +1,5 @@
+<script src="../../node_modules/steal/steal.js"
+	config="./package.json!npm"></script>
+<script type="text/steal-module">
+	console.log(window.MODULE);
+</script>

--- a/test/es_cjs/main.js
+++ b/test/es_cjs/main.js
@@ -1,0 +1,7 @@
+import { x } from './modulea';
+import y from './moduleb';
+
+window.MODULE = {
+	x: x,
+	y: y
+};

--- a/test/es_cjs/modulea.js
+++ b/test/es_cjs/modulea.js
@@ -1,0 +1,1 @@
+exports.x = 'foo';

--- a/test/es_cjs/moduleb.js
+++ b/test/es_cjs/moduleb.js
@@ -1,0 +1,1 @@
+module.exports = 'bar';

--- a/test/es_cjs/package.json
+++ b/test/es_cjs/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "app",
+	"version": "1.0.0",
+	"main": "main.js"
+}

--- a/test/es_cjs/prod.html
+++ b/test/es_cjs/prod.html
@@ -1,0 +1,4 @@
+<script src="../../node_modules/steal/steal.js"
+	config="./package.json!npm"
+	env="production"
+	main="main"></script>

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -878,6 +878,29 @@ describe("multi build", function(){
 		});
 	});
 
+	it("Loads an ES6 module that consumes CJS modules using {}", function(done){
+		rmdir(__dirname + "/es_cjs/dist", function(error){
+			if(error) return done(error);
+
+			multiBuild({
+				config: __dirname + "/es_cjs/package.json!npm"
+			}, {
+				minify: false,
+				quiet: true
+			}).then(function(){
+				open("test/es_cjs/prod.html", function(browser, close){
+						find(browser, "MODULE", function(mod){
+							assert.equal(mod.x, "foo", "got module that uses " +
+										 "{} for imports");
+							assert.equal(mod.y, "bar", "got module using default");
+
+							close();
+						}, close);
+				}, done);
+			});
+		});
+	});
+
 	describe("with plugins", function(){
 		this.timeout(60000);
 
@@ -1468,6 +1491,8 @@ describe("multi build", function(){
 				}).catch(done);
 			});
 		});
+
+
 	});
 
 	describe("importing into config", function(){


### PR DESCRIPTION
This adds a test to ensure that es/cjs interop works in production. IE, so you can have a CJS file like:

```js
exports.x = 'foo';
```

And import it in a ES6 module like:

```js
import { x } from './cjs';
```