### PR TITLE
Update tests to work with 1.0 module naming

### DIFF
--- a/test/build_conditionals_test.js
+++ b/test/build_conditionals_test.js
@@ -25,7 +25,7 @@ describe("build app using steal-conditional", function() {
 
 		prmdir(path.join(basePath, "substitution", "dist"))
 			.then(function() {
-				return multiBuild(config);
+				return multiBuild(config, { minify: false, quiet: true });
 			})
 			.then(function() {
 				var bundlesPath = path.join(basePath, "substitution", "main.js");
@@ -51,17 +51,20 @@ describe("build app using steal-conditional", function() {
 	});
 
 	it("simple boolean conditional works", function(done) {
+		this.timeout(10000);
+
 		var options = {
 			config: path.join(basePath, "boolean", "package.json!npm")
 		};
 
 		prmdir(path.join(basePath, "boolean", "dist"))
 			.then(function() {
-				return multiBuild(options, { minify: false });
+				return multiBuild(options, { minify: false, quiet: true });
 			})
 			.then(function() {
 				var bundlesPath = path.join(
-					basePath, "boolean", "dist", "bundles", "main.js"
+					basePath, "boolean", "dist", "bundles", "conditionals",
+					"main.js"
 				);
 
 				if (!fs.existsSync(bundlesPath)) {

--- a/test/bundle_assets/prod.html
+++ b/test/bundle_assets/prod.html
@@ -1,6 +1,7 @@
 <html>
 <head><title>test</title></head>
 <body>
-<script src="dist/node_modules/steal/steal.production.js" data-main="main"></script>
+<script src="dist/node_modules/steal/steal.production.js"
+	main="bundle_assets/main"></script>
 </body>
 </html>

--- a/test/conditionals/boolean/index.html
+++ b/test/conditionals/boolean/index.html
@@ -5,10 +5,10 @@
 		<title>conditional modules build</title>
 	</head>
 	<body>
-	<script data-main="main"
+	<script data-main="conditionals/main"
 			data-env="production"
 			data-config="package.json!npm"
-			src="../../../bower_components/steal/steal.js">
+			src="../../../node_modules/steal/steal.js">
 		</script>
 	</body>
 </html>

--- a/test/conditionals/substitution/index.html
+++ b/test/conditionals/substitution/index.html
@@ -6,9 +6,9 @@
 	</head>
 	<body>
 	<script data-env="production"
-			data-main="main"
+			data-main="conditionals/main"
 			data-config="package.json!npm"
-			src="../../../bower_components/steal/steal.js">
+			src="../../../node_modules/steal/steal.js">
 		</script>
 	</body>
 </html>

--- a/test/es_cjs/prod.html
+++ b/test/es_cjs/prod.html
@@ -1,4 +1,4 @@
 <script src="../../node_modules/steal/steal.js"
 	config="./package.json!npm"
 	env="production"
-	main="main"></script>
+	main="app/main"></script>

--- a/test/graph_stream_test.js
+++ b/test/graph_stream_test.js
@@ -33,15 +33,19 @@ describe("streams.graph", function(){
 		};
 		var options = { quiet: true };
 
+		function get(graph, modulePath) {
+			return graph["app@1.0.0#" + modulePath];
+		}
+
 		var graphStream = s.graph(system, options);
 
 		graphStream.pipe(through.obj(function(data){
 			var graph = data.graph;
-			assert(graph.main, "Got the main");
+			assert(get(graph, "main"), "Got the main");
 			assert(!graph.dep, "There is no dep");
 			assert(!graph.other, "There is no other");
-			assert(graph.foo, "foo is part of the graph");
-			assert(graph.bar, "bar is part of the graph");
+			assert(get(graph, "foo"), "foo is part of the graph");
+			assert(get(graph, "bar"), "bar is part of the graph");
 			done();
 		}));
 	});

--- a/test/json/prod.html
+++ b/test/json/prod.html
@@ -1,4 +1,4 @@
-<script src="../../bower_components/steal/steal.js"
+<script src="../../node_modules/steal/steal.js"
 		env="production"
-		base-url="./"
-		main="main"></script>
+		config="./package.json!npm"
+		main="jsontest/main"></script>

--- a/test/live_reload/prod.html
+++ b/test/live_reload/prod.html
@@ -2,4 +2,4 @@
         env="window-production"
         data-base-url="./"
         data-config="./package.json!npm"
-        main="main"></script>
+        main="live-app/main"></script>

--- a/test/progressive_package/dev.html
+++ b/test/progressive_package/dev.html
@@ -1,2 +1,2 @@
-<script src="../../bower_components/steal/steal.js"
+<script src="../../node_modules/steal/steal.js"
 config="package.json!npm"></script>

--- a/test/progressive_package/prod.html
+++ b/test/progressive_package/prod.html
@@ -1,3 +1,3 @@
-<script src="../../bower_components/steal/steal.js"
+<script src="../../node_modules/steal/steal.js"
 env="window-production"
-config="package.json!npm" main="main"></script>
+config="package.json!npm" main="app/main"></script>

--- a/test/recycle_test.js
+++ b/test/recycle_test.js
@@ -21,7 +21,8 @@ describe("Recycle", function(){
 		var options = {
 			localStealConfig: {
 				env: "build-development"
-			}
+			},
+			quiet: true
 		};
 
 		var depStream = bundle.createBundleGraphStream(config, options);
@@ -31,14 +32,14 @@ describe("Recycle", function(){
 
 		// Wait for it to initially finish loading.
 		recycleStream.once("data", function(data){
-			var node = data.graph.foo;
+			var node = data.graph["live-app@1.0.0#foo"];
 			var mockOptions = {};
 			// Fake string as the source.
 			mockOptions[node.load.address.replace("file:", "")] = "module.exports = 'foo'";
 			mockFs(mockOptions);
 
 			recycleStream.once("data", function(data){
-				var node = data.graph.main;
+				var node = data.graph["live-app@1.0.0#main"];
 
 				assert(/foo/.test(node.load.source), "Source changed");
 				done();
@@ -56,7 +57,7 @@ describe("Recycle", function(){
 			map: { "@dev": "@empty" }
 		};
 
-		var depStream = bundle.createBundleGraphStream(config);
+		var depStream = bundle.createBundleGraphStream(config, { quiet: true });
 		var recycleStream = recycle(config);
 
 		depStream.pipe(recycleStream);
@@ -98,7 +99,7 @@ describe("Recycle", function(){
 		};
 		var fileSystem = {};
 
-		var depStream = bundle.createBundleGraphStream(config);
+		var depStream = bundle.createBundleGraphStream(config, { quiet: true });
 		var recycleStream = recycle(config);
 
 		depStream.pipe(recycleStream);

--- a/test/side_bundle/prod.html
+++ b/test/side_bundle/prod.html
@@ -1,4 +1,4 @@
-<script src="../../bower_components/steal/steal.js"
+<script src="../../node_modules/steal/steal.js"
 	data-env="production"
 	data-config="./package.json!npm"
-	data-main="main"></script>
+	data-main="ignore_true/main"></script>

--- a/test/side_bundle_dep/prod.html
+++ b/test/side_bundle_dep/prod.html
@@ -1,4 +1,4 @@
-<script src="../../bower_components/steal/steal.js"
+<script src="../../node_modules/steal/steal.js"
 	data-env="production"
 	data-config="./package.json!npm"
-	data-main="main"></script>
+	data-main="side/main"></script>

--- a/test/test_live.js
+++ b/test/test_live.js
@@ -53,7 +53,7 @@ describe("live-reload", function(){
 				var newSource = "module.exports = 'foo';";
 				asap(fs.writeFile)(fooPath, newSource, "utf8").then(function(){
 					liveStream.once("data", function(data){
-						assert(/foo/.test(data.graph.foo.load.source),
+						assert(/foo/.test(data.graph["live-app@1.0.0#foo"].load.source),
 							"New source contains 'foo'");
 						done();
 					});


### PR DESCRIPTION
This updates our tests to use the 1.0 module naming; when using the npm plugin the System.main will always include the package name. This means that when you add `main=` in the production script tag you must include the package name because the main bundle will be `dist/bundles/packageName/main`.