### PR TITLE
Update global-css to handle case where there is no css

### DIFF
--- a/lib/build/transform.js
+++ b/lib/build/transform.js
@@ -86,6 +86,12 @@ var transformImport = function(config, transformOptions){
 				nodesInBundle = transformImport.notIgnored(nodes, ignores);
 			}
 
+			// If there's nothing in this bundle, just give them an empty
+			// source object.
+			if(nodesInBundle.length === 0) {
+				return {code: ""};
+			}
+
 			// resets the active source to be worked from.
 			removeActiveSourceKeys(nodesInBundle, options);
 

--- a/test/export_test.js
+++ b/test/export_test.js
@@ -376,7 +376,39 @@ describe("export", function(){
 
 
 			}, done);
+		});
 
+		describe("+global-css", function(){
+			it("Builds even if there is no css", function(done){
+				rmdir(__dirname + "/exports_basics/dist", function(err){
+					if(err) return done(err);
+
+					stealExport({
+						system: {
+							config: __dirname + "/exports_basics/package.json!npm",
+							main: "app/main-no-css"
+						},
+						options: { quiet: true },
+						outputs: {
+							"+global-css": {},
+							"+global-js": {
+								exports: {
+									"app/main-no-css": "MOD"
+								}
+							}
+						}
+					}).then(function(){
+						open("test/exports_basics/prod-no-css.html",
+							function(browser, close) {
+							find(browser, "MOD", function(mod){
+								assert.equal(mod.foo, "this is a blank main",
+											 "did export the js");
+								close();
+							}, close);
+						}, done);
+					});
+				});
+			});
 		});
 
 		it("+cjs +amd +global-css +global-js using Babel", function(done){

--- a/test/exports_basics/main-no-css.js
+++ b/test/exports_basics/main-no-css.js
@@ -1,0 +1,1 @@
+exports.foo = "this is a blank main";

--- a/test/exports_basics/prod-no-css.html
+++ b/test/exports_basics/prod-no-css.html
@@ -1,0 +1,1 @@
+<script src="./dist/global/app.js"></script>


### PR DESCRIPTION
Using the global-css helper should not fail just because the project doesn't contain any css. Instead it should just write out a blank file for the css (because you did ask for css I think we are obliged to write out a file anyways).

Closes #478