### PR TITLE
Better global exports for ES modules

### DIFF
--- a/lib/bundle/shim.js
+++ b/lib/bundle/shim.js
@@ -28,6 +28,14 @@ function(exports, global, doEval){ // jshint ignore:line
 		part = parts[parts.length - 1];
 		cur[part] = val;
 	};
+	var useDefault = function(mod){
+		if(!mod || !mod.__esModule) return false;
+		var esProps = { __esModule: true, "default": true };
+		for(var p in mod) {
+			if(!esProps[p]) return false;
+		}
+		return true;
+	};
 	var modules = (global.define && global.define.modules) ||
 		(global._define && global._define.modules) || {};
 	var ourDefine = global.define = function(moduleName, deps, callback){
@@ -71,6 +79,9 @@ function(exports, global, doEval){ // jshint ignore:line
 		// Set global exports
 		var globalExport = exports[moduleName];
 		if(globalExport && !get(globalExport)) {
+			if(useDefault(result)) {
+				result = result["default"];
+			}
 			set(globalExport, result);
 		}
 	};

--- a/test/export_global_css_test.js
+++ b/test/export_global_css_test.js
@@ -1,0 +1,40 @@
+var assert = require("assert");
+var stealExport = require("../lib/build/export");
+var rmdir = require("rimraf");
+var testHelpers = require("./helpers");
+
+var find = testHelpers.find;
+var open = testHelpers.open;
+
+describe("+global-css", function(){
+	it("Builds even if there is no css", function(done){
+		rmdir(__dirname + "/exports_basics/dist", function(err){
+			if(err) return done(err);
+
+			stealExport({
+				system: {
+					config: __dirname + "/exports_basics/package.json!npm",
+					main: "app/main-no-css"
+				},
+				options: { quiet: true },
+				outputs: {
+					"+global-css": {},
+					"+global-js": {
+						exports: {
+							"app/main-no-css": "MOD"
+						}
+					}
+				}
+			}).then(function(){
+				open("test/exports_basics/prod-no-css.html",
+					function(browser, close) {
+					find(browser, "MOD", function(mod){
+						assert.equal(mod.foo, "this is a blank main",
+									 "did export the js");
+						close();
+					}, close);
+				}, done);
+			});
+		});
+	});
+});

--- a/test/export_global_js_test.js
+++ b/test/export_global_js_test.js
@@ -1,0 +1,99 @@
+var assert = require("assert");
+var stealExport = require("../lib/build/export");
+var rmdir = require("rimraf");
+var testHelpers = require("./helpers");
+
+var find = testHelpers.find;
+var open = testHelpers.open;
+
+describe("+global-js", function(){
+	describe("How ES modules are exported", function(){
+		beforeEach(function(done){
+			rmdir(__dirname + "/exports_es/dist", function(err){
+				if(err) return done(err);
+				done();
+			});
+		});
+
+		it("Exports to an object if multiple exports are used", function(done){
+			stealExport({
+				system: {
+					config: __dirname + "/exports_es/package.json!npm",
+					main: "app/multi"
+				},
+				options: { quiet: true },
+				outputs: {
+					"+global-js": {
+						exports: {
+							"app/multi": "MOD"
+						}
+					}
+				}
+			}).then(function(){
+				open("test/exports_es/prod.html",
+					function(browser, close) {
+					find(browser, "MOD", function(mod){
+						assert.equal(mod.a(), "a");
+						assert.equal(mod.b(), "b");
+						close();
+					}, close);
+				}, done);
+			});
+		});
+
+		it("Exports to a single value, if there is only a single default export (traceur)",
+		   function(done){
+			stealExport({
+				system: {
+					config: __dirname + "/exports_es/package.json!npm",
+					main: "app/single",
+					transpiler: "traceur"
+				},
+				options: { quiet: true },
+				outputs: {
+					"+global-js": {
+						exports: {
+							"app/single": "MOD"
+						}
+					}
+				}
+			}).then(function(){
+				open("test/exports_es/prod.html",
+					function(browser, close) {
+					find(browser, "MOD", function(mod){
+						assert.equal(mod(), "worked");
+						close();
+					}, close);
+				}, done);
+			});
+		});
+
+		it("Exports to a single value, if there is only a single default export (babel)",
+		   function(done){
+			stealExport({
+				system: {
+					config: __dirname + "/exports_es/package.json!npm",
+					main: "app/single",
+					transpiler: "babel"
+				},
+				options: { quiet: true },
+				outputs: {
+					"+global-js": {
+						exports: {
+							"app/single": "MOD"
+						}
+					}
+				}
+			}).then(function(){
+				open("test/exports_es/prod.html",
+					function(browser, close) {
+					find(browser, "MOD", function(mod){
+						assert.equal(mod(), "worked");
+						close();
+					}, close);
+				}, done);
+			});
+		});
+
+	});
+});

--- a/test/export_standalone_test.js
+++ b/test/export_standalone_test.js
@@ -1,0 +1,38 @@
+var assert = require("assert");
+var stealExport = require("../lib/build/export");
+var rmdir = require("rimraf");
+var testHelpers = require("./helpers");
+
+var find = testHelpers.find;
+var open = testHelpers.open;
+
+
+describe("+standalone", function(){
+	it("Works with exporting a module from a dependency", function(done){
+		this.timeout(10000);
+		stealExport({
+			system: {
+				config: __dirname+"/exports_basics/package.json!npm"
+			},
+			options: { quiet: true },
+			"outputs": {
+				"+standalone": {
+					exports: {
+						"foo": "FOO.foo"
+					},
+					dest: __dirname + "/exports_basics/out.js"
+				}
+			}
+		})
+		.then(function() {
+			open("test/exports_basics/global.html",
+				 function(browser, close) {
+				find(browser,"FOO", function(foo){
+					assert.equal(foo.foo.bar.name, "bar", "it worked");
+					close();
+				}, close);
+			}, done);
+		}, done);
+
+	});
+});

--- a/test/export_test.js
+++ b/test/export_test.js
@@ -378,39 +378,6 @@ describe("export", function(){
 			}, done);
 		});
 
-		describe("+global-css", function(){
-			it("Builds even if there is no css", function(done){
-				rmdir(__dirname + "/exports_basics/dist", function(err){
-					if(err) return done(err);
-
-					stealExport({
-						system: {
-							config: __dirname + "/exports_basics/package.json!npm",
-							main: "app/main-no-css"
-						},
-						options: { quiet: true },
-						outputs: {
-							"+global-css": {},
-							"+global-js": {
-								exports: {
-									"app/main-no-css": "MOD"
-								}
-							}
-						}
-					}).then(function(){
-						open("test/exports_basics/prod-no-css.html",
-							function(browser, close) {
-							find(browser, "MOD", function(mod){
-								assert.equal(mod.foo, "this is a blank main",
-											 "did export the js");
-								close();
-							}, close);
-						}, done);
-					});
-				});
-			});
-		});
-
 		it("+cjs +amd +global-css +global-js using Babel", function(done){
 			this.timeout(10000);
 			stealExport({
@@ -462,36 +429,6 @@ describe("export", function(){
 					}, close);
 				}, done);
 			}, done);
-		});
-
-		describe("+standalone", function(){
-			it("Works with exporting a module from a dependency", function(done){
-				this.timeout(10000);
-				stealExport({
-					system: {
-						config: __dirname+"/exports_basics/package.json!npm"
-					},
-					options: { quiet: true },
-					"outputs": {
-						"+standalone": {
-							exports: {
-								"foo": "FOO.foo"
-							},
-							dest: __dirname + "/exports_basics/out.js"
-						}
-					}
-				})
-				.then(function() {
-					open("test/exports_basics/global.html",
-						 function(browser, close) {
-						find(browser,"FOO", function(foo){
-							assert.equal(foo.foo.bar.name, "bar", "it worked");
-							close();
-						}, close);
-					}, done);
-				}, done);
-
-			});
 		});
 
 	});

--- a/test/exports_es/multi.js
+++ b/test/exports_es/multi.js
@@ -1,0 +1,7 @@
+export function a(){
+	return "a";
+}
+
+export function b() {
+	return "b";
+}

--- a/test/exports_es/package.json
+++ b/test/exports_es/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "app",
+	"main": "index.js",
+	"version": "1.0.0"
+}

--- a/test/exports_es/prod.html
+++ b/test/exports_es/prod.html
@@ -1,0 +1,1 @@
+<script src="./dist/global/app.js"></script>

--- a/test/exports_es/single.js
+++ b/test/exports_es/single.js
@@ -1,0 +1,3 @@
+export default function(){
+	return "worked";
+}

--- a/test/test.js
+++ b/test/test.js
@@ -35,6 +35,9 @@ if(!isIOjs) {
 require("./multibuild_test");
 require("./transform_test");
 require("./export_test");
+require("./export_global_js_test");
+require("./export_global_css_test");
+require("./export_standalone_test");
 require("./continuous_test");
 require("./concat_test");
 require("./graph_stream_test");


### PR DESCRIPTION
This makes the global export (the one that is put on the window) nicer for ES modules. It makes it so that:

* If there are multiple named exports, the Module is placed on the global property.
* If there is only a single default export, the "default" is placed on the global property.

Closes #480