### PR TITLE
make engine-dependencies work

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     }
   ],
   "scripts": {
-    "postinstall": "install-engine-dependencies",
+    "postinstall": "npm run install-engine-dependencies",
+    "install-engine-dependencies": "install-engine-dependencies",
     "test": "npm run mocha && npm run test:browser",
     "test:browser": "npm run worker-test-build && testee test/browser/test.html --browsers firefox --reporter Spec",
     "worker-test-build": "node bin/steal build --main worker --config test/browser/webworker/stealconfig.js --bundle-steal --quiet",

--- a/package.json
+++ b/package.json
@@ -110,8 +110,7 @@
     }
   ],
   "scripts": {
-    "postinstall": "npm run install-engine-dependencies",
-    "install-engine-dependencies": "install-engine-dependencies",
+    "prepublish": "install-engine-dependencies",
     "test": "npm run mocha && npm run test:browser",
     "test:browser": "npm run worker-test-build && testee test/browser/test.html --browsers firefox --reporter Spec",
     "worker-test-build": "node bin/steal build --main worker --config test/browser/webworker/stealconfig.js --bundle-steal --quiet",


### PR DESCRIPTION
`postinstall: install-engine-dependencies` does not work if the module is not installed globally.
see also
https://github.com/rxaviers/cldr-data-npm/issues/33#issuecomment-227923754


@matthewp with `prepublish` now `zombi` is not installed on the users local machine. 
we should really make installing steal-tools more lighter. nobody need `bower` if using steal-tools for building apps. https://github.com/stealjs/steal-tools/blob/major/package.json#L37

should close https://github.com/stealjs/steal-tools/issues/484