### PR TITLE
Add websocket ssl (wss) support to live-reload

### DIFF
--- a/lib/cli/cmd_live_reload.js
+++ b/lib/cli/cmd_live_reload.js
@@ -2,6 +2,7 @@ var _assign = require("lodash/assign");
 var clone = require("lodash/cloneDeep");
 var makeSystem = require("./make_system");
 var options = clone(require("./options"));
+var winston = require("winston");
 
 module.exports = {
 	command: "live-reload",
@@ -11,6 +12,21 @@ module.exports = {
 			type: "string",
 			default: 8012,
 			describe: "Specify a port to use for the websocket server"
+		},
+		"ssl-key": {
+			type: "string",
+			default: null,
+			describe: "Path to the private key of the server in PEM format"
+		},
+		"ssl-cert": {
+			type: "string",
+			default: null,
+			describe: "Path to the certificate key of the server in PEM format"
+		},
+		"ssl-pfx": {
+			type: "string",
+			default: null,
+			describe: "Path to the private key, certificate and CA certs of the server in PFX or PKCS12 format"
 		}
 	}),
 
@@ -21,6 +37,11 @@ module.exports = {
 
 		var options = argv;
 		var system = makeSystem(argv);
+
+		if ((options.sslCert && !options.sslKey) || (options.sslKey && !options.sslCert)) {
+			winston.error("ssl-key and ssl-cert are dependant and must be specified together".red);
+			process.exit(1);
+		}
 
 		options.liveReload = true;
 		options.quiet = true;

--- a/lib/create_websocket_server.js
+++ b/lib/create_websocket_server.js
@@ -1,18 +1,29 @@
 var WebSocketServer = require("ws").Server;
-var http = require("http");
+var fs = require("fs");
 
-module.exports = function(options){
+module.exports = function(options) {
 	var port = options.liveReloadPort || 8012;
 
 	return new Promise(function(resolve, reject){
-		var server = http.createServer().listen(port);
+		var server;
+		if (options.sslCert && options.sslKey) {
+			server = require("https").createServer({
+				cert: fs.readFileSync(options.sslCert),
+				key: fs.readFileSync(options.sslKey)	
+			});
+		} else if (options.sslPfx) {
+			server = require("https").createServer({
+				pfx: fs.readFileSync(options.sslPfx)
+			});
+		} else {
+			server = require("http").createServer();
+		}
 
 		server.on("listening", function(){
 			var wss = new WebSocketServer({ server: server });
 			wss.on("connection", function(){
 				console.error("Received client connection");
 			});
-
 			resolve(wss);
 		});
 
@@ -23,5 +34,7 @@ module.exports = function(options){
 			}
 			reject(err);
 		});
+
+		server.listen(port);
 	});
 };

--- a/test/cli/cmd_live_test.js
+++ b/test/cli/cmd_live_test.js
@@ -6,7 +6,10 @@ describe("cmd live-reload module", function() {
 	var liveArgs;
 	var cmdBuildPath = "../../lib/cli/cmd_live_reload";
 
+	var exit;
 	beforeEach(function() {
+		exit = process.exit;
+
 		liveArgs = {};
 
 		mockery.enable({
@@ -26,6 +29,8 @@ describe("cmd live-reload module", function() {
 	});
 
 	afterEach(function() {
+		process.exit = exit;
+
 		mockery.disable();
 		mockery.deregisterAll();
 	});
@@ -35,5 +40,27 @@ describe("cmd live-reload module", function() {
 			config: "package.json!npm"
 		});
 		assert.ok(liveArgs.options.quiet, "defaults to quiet");
+	});
+
+	it("fails if ssl-cert is provided without ssl-key", function(done) {
+		process.exit = function(code) {
+			assert(code > 0, "Requires ssl-key config option if ssl-cert provided");
+			done();
+		};
+		cmdBuild.handler({
+			config: "",
+			sslCert: "./keys/cert.pem"
+		});
+	});
+
+	it("fails if ssl-key is provided without ssl-cert", function(done) {
+		process.exit = function(code) {
+			assert(code > 0, "Requires ssl-cert config option if ssl-key provided");
+			done();
+		};
+		cmdBuild.handler({
+			config: "",
+			sslKey: "./keys/key.pem"
+		});
 	});
 });


### PR DESCRIPTION
JSHint

Add tests

Refactor tests to not throw assertion exception