### PR TITLE
Add test to config that source maps works with configDeps

### DIFF
--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -2308,5 +2308,27 @@ describe("multi build", function(){
 				}, done);
 			});
 		});
+
+		it("works with configDependencies", function(done){
+			asap(rmdir)(__dirname + "/npm-config-dep/dist")
+			.then(function(){
+				var p = multiBuild({
+					config: __dirname + "/npm-config-dep/package.json!npm"
+				}, {
+					quiet: true,
+					sourceMaps: true,
+					sourceMapsContent: true,
+					minify: false
+				});
+				return p;
+			})
+			.then(function(){
+				var str = fs.readFileSync(__dirname + "/npm-config-dep/dist/bundles/main.js.map", "utf8");
+				var data = JSON.parse(str);
+				var expected = "../../foo.js";
+				assert.equal(data.sources[2], expected);
+			})
+			.then(done, done);
+		});
 	});
 });

--- a/test/npm-config-dep/foo.js
+++ b/test/npm-config-dep/foo.js
@@ -1,0 +1,1 @@
+exports.foo = 'bar';

--- a/test/npm-config-dep/main.js
+++ b/test/npm-config-dep/main.js
@@ -1,0 +1,1 @@
+exports.foo = 'bar';

--- a/test/npm-config-dep/package.json
+++ b/test/npm-config-dep/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "npmc",
+	"version": "1.0.0",
+	"main": "main.js",
+	"system": {
+		"configDependencies": [
+			"foo"
+		]
+	}
+}


### PR DESCRIPTION
This adds a test to confirm that source maps work with configDependencies. This test has a config dependency and then confirms that the dep is included as a source in the main bundle's sourceMap.

Related to #509