### PR TITLE
improve SystemConfig docs

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -5,25 +5,10 @@ Build a module and all of its dependencies and, optionally, other bundles to pro
 
 @signature `stealTools.build(config, options)`
 
-@param {steal-tools.SystemConfig} config
-
-Specifies configuration values to set on the System loader.  In addition to the `main`, `config`, `baseUrl` and `meta` values 
-specified in [steal-tools.SystemConfig], an additional `bundlesPath` or `bundle` is sometimes provided.
-
-
-  @option {String} [bundlesPath='dist/bundle']  Specifies the path where the production bundles should be 
-  placed. Often, this is the same value as [System.bundlesPath]. By default, the location is `"dist/bundles"`.
-
-  The path can be specified in three ways:
-
- - Absolute path - bundlesPath starts with `/`, or matches _/^\w+:[\/\\]/_, like:  `__dirname+"/place"`, or `"c:\my\bundles"`.
- - Relative to `process.cwd()` - bundlesPath starts with `./`, like `"./place"`.
- - Relative to [System.baseURL baseURL] - bundlesPath looks like: "packages", "foo/bar".
- 
-  @option {Array.<moduleName>} bundle An array of module names that should be progressively loaded.
+@param {steal-tools.SystemConfig} config 
+Specifies configuration values to set on the System loader.
   
 @param {steal-tools.BuildOptions} [options]
-
 Specifies the behavior of the build.
   
 @return {(Promise<steal-tools.BuildResult>|Stream<steal-tools.BuildResult>)} Either a Promise that resolves when the build is complete or a Stream that will send `data` events every time a rebuild is complete. By default a Promise is returned, unless the `watch` option is enabled.

--- a/doc/types/system-config.md
+++ b/doc/types/system-config.md
@@ -4,16 +4,36 @@
 Configuration values needed for StealJS to load modules. Some set of the following
 values are required:
 
-@option {String|Array<moduleName>} main The module, or modules, that should be 
-imported.  This sets [System.main].  
+@option {String|Array<moduleName>} [main] The module, or modules, that should be 
+imported.  This sets [System.main]. 
+
+ - __It is optional if__ a `config` is provided.
 
 @option {String} [config] The path to a configuration file. This
 will also specify `baseURL`, and sometimes `main`. This sets [System.configPath].
+
+ - __It is optional if__ `main` is provided and no other configurations are needed.
+ - __It is required if__ you are using NPM.
 
 @option {Object<moduleName,metadata>} [meta] A object of <moduleNames> that contain [metadata](http://stealjs.com/docs/System.meta.html)
 
 @option {String} [baseURL] If a configuration file is not used, 
 the [System.baseURL baseURL] value must be set.
+
+@option {String} [bundlesPath='dist/bundle']  Specifies the path where the production bundles should be 
+  placed. Often, this is the same value as [System.bundlesPath]. By default, the location is `"dist/bundles"`.
+
+  The path can be specified in three ways:
+
+ - Absolute path - bundlesPath starts with `/`, or matches _/^\w+:[\/\\]/_, like:  `__dirname+"/place"`, or `"c:\my\bundles"`.
+ - Relative to `process.cwd()` - bundlesPath starts with `./`, like `"./place"`.
+ - Relative to [System.baseURL baseURL] - bundlesPath looks like: "packages", "foo/bar".
+ 
+@option {Array<moduleName>} [bundle] An array of <moduleNames> that should be progressively loaded.
+  
+@option {Object<System.jsonOptions>} [jsonOptions] Provides options that can be applied to JSON loading.
+  Using the `transform` method will run through all JSON files while building, also the `package.json`'s of loaded modules
+  (if using NPM). 
 
 @body
 


### PR DESCRIPTION
added jsonOptions docs https://github.com/stealjs/system-npm/pull/162
also moved the SystemConfig `bundle` and `bundlePath` from `build.md` to `system-config.md` so we have all systemConfig together.

@matthewp 
maybe we can also move the usage of `ignore` and `sourceMaps` to the `build-options.md` 

close https://github.com/stealjs/steal/issues/643