### PR TITLE
export `dest` when used with global-js/standalone

### DIFF
--- a/doc/types/export-output.md
+++ b/doc/types/export-output.md
@@ -9,8 +9,16 @@ addition to [steal-tools.transform.options].
 with their dependencies. 
 
 
-@option {Array<moduleName|comparitor>|Boolean} [eachModule] Builds each module in the list 
-with its dependendencies individually.
+@option {Array<moduleName|comparitor>} [eachModule] Builds each module in the list with its dependendencies individually. Use this if you want to create separate builds for more than one module in your graph:
+
+```js
+stealTools.export({
+	system: {
+		config: __dirname + "/package.json!npm"
+	}
+
+});
+```
 
 @option {Array<moduleName|comparitor>} [graphs] Builds each item in the graph on its own. Each dependency is 
 built individually.
@@ -94,16 +102,28 @@ will also be included.
 
 Each module specified by `eachModule` will be exported, including its dependencies individually.  For example:
 
-```
-{
-  eachModule: ["foo","bar"],
-  format: "global"
-}
+**eachModule** is useful when you want to take a dependency graph and split it into separate builds that will be combined around certain modules within that graph.
+
+For example:
+
+```js
+stealTools.export({
+	system: {
+		config: __dirname + "/package.json!npm"
+	},
+	options: {},
+	outputs: {
+		"+standalone": {
+			eachModule: [
+				"app/a",
+				"app/b"
+			]
+		}
+	}
+});
 ```
 
-This will build a "foo" export and a "bar" export.  If "foo" and "bar" both depend on "zed", "zed" will
-be included in both exports.
-
+This will build out `dist/global/app/a.js` and `dist/global/app/b.js`, both as standalone builds.
 
 ## graphs
 

--- a/lib/build/helpers/global.js
+++ b/lib/build/helpers/global.js
@@ -57,6 +57,10 @@ var make = function(buildType){
 		dest: function(loc){
 			return function(moduleName, moduleData, load, System){
 				if(loc) {
+					if(typeof loc === "function") {
+						return loc(moduleName, moduleData, load, System);
+					}
+
 					return loc;
 				} else {
 					var baseRoot = baseHelper.removeFileProtocol(System.baseURL);

--- a/test/export_standalone_test.js
+++ b/test/export_standalone_test.js
@@ -33,6 +33,33 @@ describe("+standalone", function(){
 				}, close);
 			}, done);
 		}, done);
+	});
 
+	it("Works when using dest as a function", function(done){
+		this.timeout(10000);
+
+		stealExport({
+			system: {
+				config: __dirname + "/exports_basics/package.json!npm"
+			},
+			options: { quiet: true },
+			outputs: {
+				"+standalone": {
+					exports: { "foo": "FOO.foo" },
+					dest: function(){
+						return __dirname + "/exports_basics/out.js"
+					}
+				}
+			}
+		})
+		.then(function(){
+			open("test/exports_basics/global.html",
+				 function(browser, close) {
+				find(browser,"FOO", function(foo){
+					assert.equal(foo.foo.bar.name, "bar", "it worked");
+					close();
+				}, close);
+			}, done);
+		});
 	});
 });


### PR DESCRIPTION
This fixes the global-js helper to work properly with `dest` when dest is a function. Also better documents `eachModule` slightly.

Closes #513