### PR TITLE
Strip sourcemap on sources

### DIFF
--- a/lib/buildTypes/minifyJS.js
+++ b/lib/buildTypes/minifyJS.js
@@ -1,5 +1,4 @@
 var UglifyJS = require("uglify-js");
-var removeSourceMapUrl = require("../remove_source_map_url");
 
 module.exports = function(source, options){
 	var opts = (options != null) ? options.uglifyOptions : {};
@@ -18,7 +17,5 @@ module.exports = function(source, options){
 		}
 	}
 
-	var result = UglifyJS.minify(code, opts);
-	result.code = removeSourceMapUrl(result.code);
-	return result;
+	return UglifyJS.minify(code, opts);
 };

--- a/lib/bundle/concat_source.js
+++ b/lib/bundle/concat_source.js
@@ -1,6 +1,7 @@
 var path = require("path");
 var concat = require("../source-map-concat");
 var sourceNode = require("../node/source").node;
+var removeSourceMapUrl = require("../remove_source_map_url");
 
 module.exports = function(bundle, sourceProp, excludePlugins){
 	var output = fileName(bundle);
@@ -36,7 +37,7 @@ module.exports = function(bundle, sourceProp, excludePlugins){
 
 		return {
 			node: node,
-			code: (source.code || "") + "",
+			code: removeSourceMapUrl((source.code || "") + ""),
 			map: source.map
 		};
 	}).filter(truthy);

--- a/lib/node/make_steal_node.js
+++ b/lib/node/make_steal_node.js
@@ -3,13 +3,13 @@ var fs =  require('fs'),
 
 module.exports = function(configuration){
 	var stealPath = path.join(require.resolve("steal"), "/../steal");
+	var stealSource = fs.readFileSync(path.join(stealPath +
+			(configuration.options.minify ? ".production" : "") + ".js"), 'utf8');
 
 	return {
 		load: {
 			metadata: {format: "global"},
-			source: fs.readFileSync(path.join(stealPath+
-				(configuration.options.minify ? ".production" : "")+
-				".js")),
+			source: stealSource,
 			name: "steal"
 		},
 		dependencies: [],

--- a/lib/remove_source_map_url.js
+++ b/lib/remove_source_map_url.js
@@ -1,5 +1,4 @@
-
-var expression = /\n\/\/# sourceMappingURL=(.)+$/;
+var expression = /\n\/\/# sourceMappingURL=(.)*$/m;
 
 module.exports = function(source){
 	return (source || "").replace(expression, "");

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -2330,6 +2330,29 @@ describe("multi build", function(){
 			})
 			.then(done, done);
 		});
+
+		it("strip sourcemapping URL in all files", function (done) {
+			asap(rmdir)(__dirname + "/strip-sourcemap/dist")
+				.then(function () {
+					return multiBuild({
+						config: __dirname + "/strip-sourcemap/stealconfig.js",
+						main: "main"
+					}, {
+						minify: false,
+						sourceMaps: true,
+						bundleSteal: true
+					});
+				})
+				.then(function () {
+					var source = fs.readFileSync(__dirname + "/strip-sourcemap/dist/bundles/main.js", "utf8");
+					var soureMapRegex = /\/\/# sourceMappingURL=main.js.map/m;
+					assert.ok(/\/\/# sourceMappingURL=main.js.map/m.test(source), 'sourceMap found');
+
+					assert.ok(!/\/\/# sourceMappingURL=foobar.js.map/m.test(source), 'foobar.js.map should not be found');
+					assert.ok(!/\/\/# sourceMappingURL=Promise.js.map/m.test(source), 'foobar.js.map should not be found');
+				})
+				.then(done, done);
+		})
 	});
 
 	describe("multi-main with bundled steal", function(){

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -2323,9 +2323,9 @@ describe("multi build", function(){
 				return p;
 			})
 			.then(function(){
-				var str = fs.readFileSync(__dirname + "/npm-config-dep/dist/bundles/main.js.map", "utf8");
+				var str = fs.readFileSync(__dirname + "/npm-config-dep/dist/bundles/npmc/main.js.map", "utf8");
 				var data = JSON.parse(str);
-				var expected = "../../foo.js";
+				var expected = "../../../foo.js";
 				assert.equal(data.sources[2], expected);
 			})
 			.then(done, done);

--- a/test/strip-sourcemap/a.js
+++ b/test/strip-sourcemap/a.js
@@ -1,0 +1,1 @@
+module.exports = 'a';

--- a/test/strip-sourcemap/main.js
+++ b/test/strip-sourcemap/main.js
@@ -1,0 +1,4 @@
+require('a');
+
+module.exports = 'foo';
+//# sourceMappingURL=foobar.js.map


### PR DESCRIPTION
strip source maps now while concatenating files.
also add to the sourcemap regex the `multline` parameter `/m`

this is related to: https://github.com/stealjs/steal/issues/803

with this fix, we now strip all sourcemaps on all files that will be concatenated.

