### PR TITLE
Make config optional

### DIFF
--- a/lib/assign_default_options.js
+++ b/lib/assign_default_options.js
@@ -31,6 +31,11 @@ module.exports = function(config, options){
 		});
 	}
 
+	// package.json!npm is now the default
+	if(!config.config && !config.configMain) {
+		config.configMain = "package.json!npm";
+	}
+
 	// Setup logging
 	logging.setup(options, config);
 

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -1565,7 +1565,7 @@ describe("multi build", function(){
 		beforeEach(function(done){
 			asap(rmdir)(__dirname + "/npm-directories/dist").then(function(){
 				return multiBuild({
-					config: __dirname + "/npm-directories/package.json!npm"
+					baseURL: __dirname + "/npm-directories"
 				}, {
 					quiet: true
 				});


### PR DESCRIPTION
This makes it so that setting config is not required. You can do:

```js
stealTools.build({});
```

And it will use `packag.json!npm` as the default. Closes https://github.com/stealjs/steal/issues/764