### PR TITLE
When there are no shared bundles, merge top-level bundles together

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -163,8 +163,8 @@ modules as bundles.
       minify: true,
       debug: false,
       quiet: false,
-      bundleDepth: 3,
-      mainDepth: 3
+      maxBundleRequests: 3,
+      maxMainRequests: 3
     });
 
 Assuming that "login" and "homepage" need the same modules, the following bundles will be created:

--- a/doc/types/build-options.md
+++ b/doc/types/build-options.md
@@ -17,10 +17,10 @@ Options used to configure the build process.
 For more information take a look at the `ignore` usage http://stealjs.com/docs/steal-tools.build.html#ignore
 
 
-@option {Number} [bundleDepth=3] The maximum number of bundles that need to be loaded
+@option {Number} [maxBundleRequests=3] The maximum number of bundles that need to be loaded
 for any `bundle` module. Defaults to `3`.
 
-@option {Number} [mainDepth=3] The maximum number of bundles that will be loaded for any `main`
+@option {Number} [maxMainRequests=3] The maximum number of bundles that will be loaded for any `main`
 module. Defaults to `3`.
 
 @option {Boolean} [removeDevelopmentCode=true] Remove any development code from the bundle specified 

--- a/lib/assign_default_options.js
+++ b/lib/assign_default_options.js
@@ -3,7 +3,9 @@ var assign = require("lodash").assign,
 	logging = require("./logger");
 
 module.exports = function(config, options){
-	if(options.__defaultsAssigned) return options;
+	if(options.__defaultsAssigned) {
+		return options;
+	}
 
 	options = assign({ // Defaults
 		minify: false,
@@ -11,7 +13,9 @@ module.exports = function(config, options){
 		uglifyOptions: {},
 		cleanCSSOptions: {},
 		removeDevelopmentCode: true,
-		namedDefines: true
+		namedDefines: true,
+		maxBundleRequests: options.maxBundleRequests || options.bundleDepth,
+		maxMainRequests: options.maxMainRequests || options.mainDepth
 	}, options);
 
 	if(options.sourceMaps) {

--- a/lib/bundle/depth.js
+++ b/lib/bundle/depth.js
@@ -1,12 +1,12 @@
 var DEFAULT = 3;
 
 module.exports = function(config, options, isMain){
-	if(isMain && isNumber(config.mainDepth)) {
-		return config.mainDepth;
+	if(isMain && isNumber(options.maxMainRequests)) {
+		return options.maxMainRequests;
 	}
 
-	if(isNumber(options.bundleDepth)) {
-		return options.bundleDepth;
+	if(isNumber(options.maxBundleRequests)) {
+		return options.maxBundleRequests;
 	}
 
 	return DEFAULT;

--- a/lib/bundle/flatten.js
+++ b/lib/bundle/flatten.js
@@ -8,11 +8,14 @@ var bundle = {
 		 * @param {Object} shares
 		 * @param {Object} depth
 		 */
-		flatten : function(shares, depth){
+		flatten: function(shares, depth){
+
+			debugger;
+
 			// make waste object
 			// mark the size
 			while(bundle.maxDepth(shares) > depth){
-				var min = bundle.min(shares);
+				var min = bundle.min(shares, depth);
 				if(min) {
 					bundle.merge(shares, min);
 				}
@@ -65,25 +68,29 @@ var bundle = {
 				max = 0;
 			shares.forEach(function(share){
 				share.bundles.forEach(function(appName){
-					packageDepths[appName] = (!packageDepths[appName] ? 1 : packageDepths[appName] +1 );
+					packageDepths[appName] = (!packageDepths[appName] ?
+											  1 : packageDepths[appName] +1);
 					max = Math.max(packageDepths[appName], max);
 				});
 			});
 			return max;
 		},
 		/**
-		 * Goes through every combination of shares and returns the one with the smallest difference.
-		 * Shares can have a waste property that has how much waste the share currently has 
-		 * accumulated.
+		 * Goes through every combination of shares and returns the one with
+		 * the smallest difference.
+		 * Shares can have a waste property that has how much waste the share 
+		 * currently has accumulated.
 		 * @param {{}} shares
 		 * @return {min}
 		 *     {
 		 *       waste : 123213, // the amount of waste in the composite share
-		 *       lower : share, // the more base share, whos conents should be run first
-		 *       higher: share // the less base share, whos contents should run later
+		 *       lower : share, // the more base share, whos conents should 
+		 *			be run first
+		 *       higher: share // the less base share, whos contents should
+		 *			run later
 		 *     }
 		 */
-		min: function(shares){
+		min: function(shares, depth){
 			var min = {diff: {
 				totalWaste: Infinity,
 			}, lower: 0, higher: 0};
@@ -95,8 +102,11 @@ var bundle = {
 				for(var j = i+1; j < shares.length; j++){
 					var shareB = shares[j],
 						diff;
+
+					var isTooSmall = shareB.bundles.length == 1 &&
+						depth !== 1;
 					
-					if( shareB.bundles.length == 1 ){
+					if(isTooSmall){
 						continue;
 					}
 					
@@ -127,7 +137,6 @@ var bundle = {
 		// essentially, which apps will have the waste incured by loading
 		// b
 		diff: function(sharedA, sharedB){
-			
 			// combine nodes
 			var nodes = sharedA.nodes.concat(sharedB.nodes),
 				// bundle names to their waste

--- a/lib/bundle/flatten.js
+++ b/lib/bundle/flatten.js
@@ -9,9 +9,6 @@ var bundle = {
 		 * @param {Object} depth
 		 */
 		flatten: function(shares, depth){
-
-			debugger;
-
 			// make waste object
 			// mark the size
 			while(bundle.maxDepth(shares) > depth){
@@ -46,7 +43,7 @@ var bundle = {
 			}
 			
 			// remove old one
-			shares.splice(min.higher,1);
+			shares.splice(min.higher, 1);
 			
 			// merge in files, lowers should run first
 			lower.nodes = lower.nodes.concat(upper.nodes);

--- a/test/bundleDepth/a.js
+++ b/test/bundleDepth/a.js
@@ -2,3 +2,5 @@ require("./foo");
 require("./a_other");
 require("./lorem_b");
 require("./lorem_c");
+
+window.MODULEA = "worked";

--- a/test/bundleDepth/b.js
+++ b/test/bundleDepth/b.js
@@ -3,3 +3,5 @@ require("./another");
 require("./b_other");
 require("./lorem");
 require("./lorem_c");
+
+window.MODULEB = "worked";

--- a/test/bundleDepth/package.json
+++ b/test/bundleDepth/package.json
@@ -5,8 +5,8 @@
 
 	"system": {
 		"bundle": [
-			"a",
-			"b"
+			"bd/a",
+			"bd/b"
 		]
 	}
 }

--- a/test/bundleDepth/prod.html
+++ b/test/bundleDepth/prod.html
@@ -1,0 +1,10 @@
+<script src="../../node_modules/steal/steal.js"
+	config="./package.json!npm"
+	env="production"
+	main="bd/main"></script>
+<script>
+	steal.done().then(function(){
+		steal.import("bd/a");
+		steal.import("bd/b");
+	});
+</script>

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -2450,7 +2450,7 @@ describe("multi build", function(){
 		});
 	});
 
-	describe("bundleDepth", function(){
+	describe("maxBundleRequests", function(){
 		it("can be set to 1", function(done){
 			asap(rmdir)(__dirname + "/bundleDepth/dist")
 			.then(function(){
@@ -2460,7 +2460,7 @@ describe("multi build", function(){
 					quiet: true,
 					minify: false,
 
-					bundleDepth: 1
+					maxBundleRequests: 1
 				});
 
 				return p;
@@ -2480,9 +2480,7 @@ describe("multi build", function(){
 						}, close);
 					}, function(){});
 				}, done);
-
-			})
-			.then(done, done);
+			});
 		});
 	});
 });

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -2451,7 +2451,7 @@ describe("multi build", function(){
 	});
 
 	describe("bundleDepth", function(){
-		it.only("can be set to 1", function(done){
+		it("can be set to 1", function(done){
 			asap(rmdir)(__dirname + "/bundleDepth/dist")
 			.then(function(){
 				var p = multiBuild({
@@ -2466,9 +2466,9 @@ describe("multi build", function(){
 				return p;
 			})
 			.then(function(data){
-				// check the bundles
-				assert.equal(data.bundles.length, 3, "There are only 3 bundles in this project");
+				assert.equal(data.bundles.length, 2, "there are two bundles because they were merged");
 
+				// check the bundles
 				open("test/bundleDepth/prod.html",function(browser, close){
 					find(browser,"MODULEA", function(modA){
 						assert.equal(modA, "worked");

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -2451,7 +2451,7 @@ describe("multi build", function(){
 	});
 
 	describe("bundleDepth", function(){
-		it("can be set to 1", function(done){
+		it.only("can be set to 1", function(done){
 			asap(rmdir)(__dirname + "/bundleDepth/dist")
 			.then(function(){
 				var p = multiBuild({
@@ -2468,6 +2468,19 @@ describe("multi build", function(){
 			.then(function(data){
 				// check the bundles
 				assert.equal(data.bundles.length, 3, "There are only 3 bundles in this project");
+
+				open("test/bundleDepth/prod.html",function(browser, close){
+					find(browser,"MODULEA", function(modA){
+						assert.equal(modA, "worked");
+
+						find(browser, "MODULEB", function(modB){
+							assert.equal(modB, "worked");
+
+							close();
+						}, close);
+					}, function(){});
+				}, done);
+
 			})
 			.then(done, done);
 		});


### PR DESCRIPTION
This fixes https://github.com/stealjs/steal-tools/issues/523

The solution is that when we have `bundleDepth: 1` and there are shared dependencies we merge the top-level bundles (the ones with shares) together.

This also renames `bundleDepth` to `maxBundleRequests` and documents that. The old name will be left in but deprecated.