### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - 0.10
   - 0.12
-  - "iojs"
   - 5.5
 before_script:
   - install-engine-dependencies


### PR DESCRIPTION
DEPRECATED IOJS
This image is officially deprecated in favor of the node image. Please adjust your usage accordingly!

See iojs.org for more information, specifically the following note:

io.js has merged with the Node.js project again.
There won't be any further io.js releases. All of the features in io.js are available in Node.js v4 and above.