### PR TITLE
Adds a new dest option to BuildOptions

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -80,16 +80,16 @@ otherwise, [config.baseURL] should be set like:
 ```
 
 
-## bundlesPath
+## dest
 
-The `bundlesPath` option specifies where the bundles should be looked for
-relative to [config.baseURL].  It will also change where the bundles are written out.
+The `dest` option specifies **a folder** where the distributables (which includes your bundles, a production version of Steal, and possibly other assets).
+
 
     var promise = stealTools.build({
       main: "my-app",
-      config: __dirname+"/package.json!npm",
-      bundlesPath: "mobile/assets"
+      config: __dirname+"/package.json!npm"
     },{
+	  dest: __dirname + "/mobile/assets",
       bundleSteal: true
     });
 
@@ -102,15 +102,8 @@ This will build bundles like:
 To load the bundles, a html page should have a script tag like:
 
 ```
-<script src='../mobile/assets/my-app.js' 
-        config='../package.json!npm'
-        bundles-path='mobile/assets'
-        ></script>
+<script src="../mobile/assets/steal.production.js"></script>
 ```
-
-> Notice: bundlesPath should typically not be set in your
-config file. Instead, it should be set when `.build` is called
-and as an attribute in the script that loads _steal.js_.
 
 ## <a name="ignore"></a>ignore
 

--- a/doc/types/build-options.md
+++ b/doc/types/build-options.md
@@ -11,7 +11,15 @@ Options used to configure the build process.
 
 @option {Boolean} [quiet=false] No logging.  Defaults to `false`.
 
-@option {steal-tools.BundleAssetsOptions|Boolean} [bundleAssets=false] Set to true to have assets from your project bundled into your dist folder.
+@option {String} [dest="dist"] Specifies the destination folder for the build. By default steal-tools will write to the `BASEURL + '/dist'` folder where BASEURL is the local Steal [config.baseUrl], usually the same folder that your package.json is located.
+
+  The path can be specified in three ways:
+
+ - Absolute path - dest starts with `/`, or matches _/^\w+:[\/\\]/_, like:  `__dirname+"/place"`, or `"c:\my\bundles"`.
+ - Relative to `process.cwd()` - dest starts with `./`, like `"./place"`.
+ - Relative to [config.baseURL baseURL] - dest looks like: "packages", "foo/bar".
+
+@option {steal-tools.BundleAssetsOptions|Boolean} [bundleAssets=false] Set to true to have assets from your project bundled into your dest folder.
 
 @option {Array.<moduleName>} ignore An array of module names that should be ignored and not included in the bundled file. 
 For more information take a look at the `ignore` usage http://stealjs.com/docs/steal-tools.build.html#ignore

--- a/doc/types/steal-config.md
+++ b/doc/types/steal-config.md
@@ -19,15 +19,6 @@ will also specify `baseURL`, and sometimes `main`. This sets [config.configPath]
 
 @option {String} [baseURL] If a configuration file is not used, 
 the [config.baseURL baseURL] value must be set.
-
-@option {String} [bundlesPath='dist/bundle']  Specifies the path where the production bundles should be 
-  placed. Often, this is the same value as [config.bundlesPath]. By default, the location is `"dist/bundles"`.
-
-  The path can be specified in three ways:
-
- - Absolute path - bundlesPath starts with `/`, or matches _/^\w+:[\/\\]/_, like:  `__dirname+"/place"`, or `"c:\my\bundles"`.
- - Relative to `process.cwd()` - bundlesPath starts with `./`, like `"./place"`.
- - Relative to [config.baseURL baseURL] - bundlesPath looks like: "packages", "foo/bar".
  
 @option {Array<moduleName>} [bundle] An array of <moduleNames> that should be progressively loaded.
   

--- a/lib/assign_default_options.js
+++ b/lib/assign_default_options.js
@@ -35,6 +35,10 @@ module.exports = function(config, options){
 		});
 	}
 
+	if(config.bundlesPath) {
+		throw new Error("bundlesPath has been removed. Use dest instead: http://stealjs.com/docs/steal-tools.BuildOptions.html");
+	}
+
 	// package.json!npm is now the default
 	if(!config.config && !config.configMain) {
 		config.configMain = "package.json!npm";

--- a/lib/build/multi.js
+++ b/lib/build/multi.js
@@ -80,7 +80,11 @@ module.exports = function(config, options){
 	} else {
 		// Minification is optional, but on by default
 		options.minify = options.minify !== false;
-		options = assignDefaultOptions(config, options);
+		try {
+			options = assignDefaultOptions(config, options);
+		} catch(err) {
+			return Promise.reject(err);
+		}
 
 		// Get a stream containing the bundle graph
 		var graphStream = createBundleGraphStream(config, options);

--- a/lib/bundle/make_bundles_config.js
+++ b/lib/bundle/make_bundles_config.js
@@ -48,6 +48,5 @@ function getBundlesPaths(configuration){
 	var paths = util.format('\tSystem.paths["bundles/*.css"] ="%s/*css";\n' +
 													'\tSystem.paths["bundles/*"] = "%s/*.js";\n',
 													bundlesPath, bundlesPath);
-	// TODO: we should probably give a warning to make sure you include this in your production html's configuration.
 	return "if(!System.bundlesPath) {\n" + paths + "}\n";
 }

--- a/lib/configuration/make.js
+++ b/lib/configuration/make.js
@@ -27,14 +27,17 @@ Configuration.prototype = {
 			return path.join(cleanAddress(this.loader.baseURL), src);
 		}
 	},
+	get dest() {
+		var dest = this.options.dest || "dist";
+		if(typeof dest === "function") {
+			dest = "dist";
+		}
+		return this.join(dest);
+	},
 	get bundlesPath () {
-	 	var dir = this.loader.bundlesPath;
-	 	if(dir === "") {
-	 		dir = "bundles";
-	 	} else if(!dir) {
-	 		dir = "dist/bundles";
-	 	}
-	 	return this.join( dir );
+		var dest = this.dest;
+		var dir = path.join(dest, "bundles");
+		return dir;
 	},
 	get bundlesPathURL () {
 		return path.relative( this.loader.baseURL, this.bundlesPath ).replace(/\\/g, '/');

--- a/test/bundle_path/subfolder/index.html
+++ b/test/bundle_path/subfolder/index.html
@@ -3,4 +3,4 @@
 	data-env="production"
 	data-config="./config.js"
 	data-main="main"
-	data-bundles-path="../javascript/dist"></script>
+	data-bundles-path="../javascript/dist/bundles"></script>

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -262,11 +262,11 @@ describe("multi build", function(){
 	it("Allows specifying an alternative dist directory", function(done){
 		var config = {
 			config: __dirname + "/other_bundle/stealconfig.js",
-			main: "bundle",
-			bundlesPath: __dirname + "/other_bundle/other_dist/bundles"
+			main: "bundle"
 		};
 
 		var options = {
+			dest: __dirname + "/other_bundle/other_dist",
 			quiet: true
 		};
 
@@ -288,7 +288,23 @@ describe("multi build", function(){
 			});
 
 		});
+	});
 
+	it("Throws if you use bundlesPath configuration", function(done){
+		multiBuild({
+			config: __dirname + "/some/fake/dir/package.json!npm",
+			bundlesPath: __dirname + "/some/fake/dir/bundles"
+		}, {
+			quiet: false	
+		})
+		.then(function(){
+			assert.ok(false, "This should not have succeeded");
+		}, function(err){
+			var msg = err.message;
+			assert.ok(/bundlesPath has been removed/.test(msg),
+					  "Rejected because bundlesPath is used");
+		})
+		.then(done);
 	});
 
 
@@ -296,11 +312,11 @@ describe("multi build", function(){
         this.timeout(5000);
 		var config = {
 			config: __dirname + "/other_bundle/stealconfig.js",
-			main: "bundle",
-			bundlesPath: __dirname+"/other_bundle/bundles"
+			main: "bundle"
 		};
 
 		var options = {
+			dest: __dirname + "/other_bundle",
 			quiet: true
 		};
 
@@ -325,7 +341,7 @@ describe("multi build", function(){
 
 	});
 
-	it("Works with bundlesPath and loading from a subfolder", function(done){
+	it("Works with dest and loading from a subfolder", function(done){
 		this.timeout(5000);
 
 		rmdir(__dirname + "/bundle_path/javascript/dist", function(error){
@@ -333,9 +349,9 @@ describe("multi build", function(){
 
 			multiBuild({
 				config: __dirname + "/bundle_path/config.js",
-				main: "main",
-				bundlesPath: __dirname + "/bundle_path/javascript/dist"
+				main: "main"
 			}, {
+				dest: __dirname + "/bundle_path/javascript/dist",
 				minify: false,
 				quiet: true
 			}).then(function(){
@@ -403,10 +419,10 @@ describe("multi build", function(){
 
 			multiBuild({
 				config: __dirname+"/bundle/stealconfig.js",
-				main: "bundle",
-				bundlesPath: __dirname + "/bundle/alternate/bundles"
+				main: "bundle"
 			},{
 				bundleSteal: true,
+				dest: __dirname + "/bundle/alternate",
 				quiet: true,
 				minify: false
 			}).then(function(data){
@@ -1520,9 +1536,9 @@ describe("multi build", function(){
 				var second = multiBuild({
 						config: __dirname+"/bundle/stealconfig.js",
 						main: "bundle",
-						bundlesPath: __dirname+"/bundle_multiple_builds",
 						systemName: "2"
 					}, {
+						dest: __dirname + "/bundle_multiple_builds",
 						quiet: true
 					})
 

--- a/test/other_bundle/bundle-dist.html
+++ b/test/other_bundle/bundle-dist.html
@@ -5,4 +5,5 @@
 	src="../../node_modules/steal/steal.js" 
 	data-base-url="./"
 	data-main="bundle"
+	data-bundles-path="bundles"
 	data-env="production"></script>


### PR DESCRIPTION
This adds a new `dest` option to BuildOptions that allows you to specify
the folder where bundles (and other assets if bundleAssets is used) will
be written out. It can be used like:

```js
stealTools.build({}, {
  dest: __dirname + "/path/to/dist"
})
.catch(err => console.error(err));
```

Closes #491