### PR TITLE
Build out a configured steal.production.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ test/pluginify/out.js.map
 test/nocallback/out.js
 test/dep_plugins/bundles
 test/bundles/
+test/other_bundle/steal.production.js
 test/other_bundle/other_dist/
 test/bundle/alternate/
 test/minify/bundles/

--- a/doc/build.md
+++ b/doc/build.md
@@ -23,7 +23,6 @@ module as bundles.
     var stealTools = require("steal-tools");
     
     var promise = stealTools.build({
-      main: "my-app",
       config: __dirname+"/package.json!npm"
     },{
       // the following are the default values, so you don't need
@@ -41,9 +40,7 @@ This will build bundles like:
 To load the bundles, a html page should have a script tag like:
 
 ```
-<script src='./node_modules/steal/steal.production.js' 
-        main='my-app'
-        env='production'></script>
+<script src="./dist/steal.production.js"></script>
 ```
 
 ## bundleSteal
@@ -67,18 +64,8 @@ This will build bundles like:
 To load the bundles, a html page should have a script tag like:
 
 ```
-<script src='./dist/bundles/my-app.js' 
-        config='../../package.json!npm'></script>
+<script src="./dist/bundles/my-app.js"></script>
 ```
-
-The [config.configPath] must be given if a [config.configMain config file] is in the bundle;
-otherwise, [config.baseURL] should be set like:
-
-```
-<script src='./dist/bundles/my-app.js' 
-        base-url='../../'></script>
-```
-
 
 ## dest
 
@@ -86,7 +73,6 @@ The `dest` option specifies **a folder** where the distributables (which include
 
 
     var promise = stealTools.build({
-      main: "my-app",
       config: __dirname+"/package.json!npm"
     },{
 	  dest: __dirname + "/mobile/assets",
@@ -95,7 +81,7 @@ The `dest` option specifies **a folder** where the distributables (which include
 
 This will build bundles like:
 
-    /mobile/assets/
+    /mobile/assets/bundles
       my-app.js
       my-app.css
 
@@ -194,9 +180,7 @@ Source maps provide a way to debug your bundled application. Using steal-tool's 
 This will build out your application to `dist/bundles/app.js` and a corresponding source map will be at `dist/bundles/app.js.map`. Now load your application:
 
 ```html
-<script src="./node_modules/steal/steal.js"
-    env="production"
-    main="app"></script>
+<script src="./dist/steal.production.js"></script>
 ```
 
 And look in your debugger tools, the original sources should be shown and are debuggable.

--- a/doc/guides/watch_mode.md
+++ b/doc/guides/watch_mode.md
@@ -113,9 +113,7 @@ Now that we've got a basic application written let's check out the debugging exp
 ### index.html
 
 ```html
-<script src="node_modules/steal/steal.js"
-	env="production"
-	main="main"></script>
+<script src="./dist/steal.production.js"></script>
 ```
 
 Open the page in a browser and open your debug tools. With the watch mode source maps are enabled by default. You can see and debug your original code from your browser's debugging tools.

--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ module.exports = {
 		bundle: require("./lib/stream/bundle"),
 		concat: require("./lib/bundle/concat_stream"),
 		write: require("./lib/bundle/write_bundles")
-			.createWriteStream
+			.createWriteStream,
+		steal: require("./lib/stream/steal")
 
 	}
 

--- a/lib/build/continuous.js
+++ b/lib/build/continuous.js
@@ -3,6 +3,7 @@ var recycle = require("../graph/recycle");
 var multiBuild = require("../stream/build");
 var createConcatStream = require("../bundle/concat_stream");
 var createWriteStream = require("../bundle/write_bundles").createWriteStream;
+var stealWriteStream = require("../stream/steal");
 var watch = require("../stream/watch");
 var defaults = require("lodash").defaults;
 
@@ -43,7 +44,8 @@ module.exports = function(config, options){
 		.pipe(graphStream)
 		.pipe(multiBuild(config, options))
 		.pipe(createConcatStream())
-		.pipe(createWriteStream());
+		.pipe(createWriteStream())
+		.pipe(stealWriteStream());
 
 	// Watch the build stream and call rebuild whenever it changes.
 	var watchStream = watch(graphStream);

--- a/lib/build/multi.js
+++ b/lib/build/multi.js
@@ -62,6 +62,7 @@ var assignDefaultOptions = require("../assign_default_options");
 var bundle = require("../stream/bundle");
 var createBundleGraphStream = require("../graph/make_graph_with_bundles").createBundleGraphStream;
 var createWriteStream = require("../bundle/write_bundles").createWriteStream;
+var stealWriteStream = require("../stream/steal");
 var continuousBuild = require("./continuous");
 var concat = require("../bundle/concat_stream");
 var minify = require("../stream/minify");
@@ -99,7 +100,9 @@ module.exports = function(config, options){
 		// Return a Promise that will resolve after bundles have been written;
 		return new Promise(function(resolve, reject){
 			// Pipe the build result into a write stream.
-			var writeStream = concatStream.pipe(createWriteStream());
+			var writeStream = concatStream
+				.pipe(createWriteStream())
+				.pipe(stealWriteStream());
 
 			writeStream.on("data", function(data){
 				this.end();

--- a/lib/stream/steal.js
+++ b/lib/stream/steal.js
@@ -1,0 +1,75 @@
+var asap = require("pdenodeify");
+var path = require("path");
+var through = require("through2");
+var fs = require("fs-extra");
+var npmUtils = require("steal/ext/npm-utils");
+
+module.exports = function(){
+	return through.obj(function(data, enc, done){
+		addConfiguredSteal(data)
+		.then(function(){
+			done(null, data);
+		}, function(err){
+			done(err);
+		});
+	});
+};
+
+function addConfiguredSteal(data) {
+	var configuration = data.configuration;
+	var options = data.options;
+	var dest = configuration.dest;
+	var stealProductionDest = path.join(dest, "steal.production.js");
+
+	// Don't do this if we are bundling steal
+	if(options.bundleSteal) {
+		return Promise.resolve();
+	}
+
+	var stealProject = require.resolve("steal");
+
+	var stealPath = path.join(
+		path.dirname(stealProject),
+		"steal.production.js"
+	);
+
+	return asap(fs.readFile)(stealPath, "utf8")
+	.then(function(src){
+		return appendConfig(src, data);
+	})
+	.then(function(src){
+		return asap(fs.outputFile)(stealProductionDest, src, "utf8");
+	});
+}
+
+function appendConfig(src, data) {
+	var main = data.mains[0];
+	var configMain = data.steal.System.configMain;
+
+	var configSrc = [
+		"if(typeof steal === \"undefined\") steal = {};",
+		"steal.bundlesPath = \"bundles\";",
+		"steal.main = \"" + denormalize(main) + "\";",
+		"steal.configMain = \"" + configMain + "\";"
+	].join("\n");
+
+	return configSrc + "\n" + src;
+}
+
+function denormalize(name) {
+	if(npmUtils.moduleName.isNpm(name)) {
+		var parsed = npmUtils.moduleName.parse(name);
+		name = parsedToFriendly(parsed);
+
+		if(parsed.plugin) {
+			var parsedPlugin = npmUtils.moduleName.parse(parsed.plugin.substr(1));
+			name += "!" + parsedToFriendly(parsedPlugin);
+		}
+	}
+	return name;
+}
+
+function parsedToFriendly(parsed) {
+	var name = parsed.packageName + "/" + parsed.modulePath;
+	return name;
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "pdenodeify": "^0.1.0",
     "bitovi-source-map": "0.4.2-bitovi.2",
     "steal": "^1.0.0-rc.8",
-    "steal-bundler": "^0.2.4",
+    "steal-bundler": "^0.3.0",
     "system-parse-amd": "0.0.2",
     "through2": "^2.0.0",
     "tmp": "0.0.26",

--- a/test/build_types/prod.html
+++ b/test/build_types/prod.html
@@ -1,5 +1,2 @@
 <div id="test-element">#test-element</div>
-<script src="../../bower_components/steal/steal.js"
-        data-main="main"
-        data-env="production"
-        data-config="./config.js"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/bundle/bundle.html
+++ b/test/bundle/bundle.html
@@ -1,5 +1,1 @@
-<script 
-	src="../../node_modules/steal/steal.js" 
-	data-base-url="./"
-	main="bundle"
-	data-env="production"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/bundleDepth/prod.html
+++ b/test/bundleDepth/prod.html
@@ -1,7 +1,4 @@
-<script src="../../node_modules/steal/steal.js"
-	config="./package.json!npm"
-	env="production"
-	main="bd/main"></script>
+<script src="./dist/steal.production.js"></script>
 <script>
 	steal.done().then(function(){
 		steal.import("bd/a");

--- a/test/bundle_assets/prod.html
+++ b/test/bundle_assets/prod.html
@@ -1,7 +1,7 @@
 <html>
 <head><title>test</title></head>
 <body>
-<script src="dist/node_modules/steal/steal.production.js"
+<script src="./dist/steal.production.js"
 	main="bundle_assets/main"></script>
 </body>
 </html>

--- a/test/bundle_false/prod.html
+++ b/test/bundle_false/prod.html
@@ -1,5 +1,1 @@
-<script src="../../node_modules/steal/steal.js"
-        env="window-production"
-        data-base-url="./"
-        data-config="./package.json!npm"
-        main="src/main"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/circular/prod.html
+++ b/test/circular/prod.html
@@ -1,5 +1,1 @@
-<script src="../../bower_components/steal/steal.js"
-		base-url="./"
-		config="package.json!npm"
-		main="circular/main"
-		env="production"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/commonjs/prod.html
+++ b/test/commonjs/prod.html
@@ -1,4 +1,1 @@
-<script src="../../bower_components/steal/steal.js"
-		data-env="production"
-		data-bundles-path="test/commonjs/dist/bundles"
-		data-main="main"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/css_paths/prod.html
+++ b/test/css_paths/prod.html
@@ -1,7 +1,1 @@
-<body>
-	<script type="text/javascript"
-		src="../../bower_components/steal/steal.js"
-		data-config="./config.js"
-		data-main="main"
-		data-env="production"></script>
-</body>
+<script src="./dist/steal.production.js"></script>

--- a/test/current-loader/config-plugin.html
+++ b/test/current-loader/config-plugin.html
@@ -1,4 +1,1 @@
-<script src="../../bower_components/steal/steal.js"
-		data-main="main-plugin"
-		data-config ="config.js"
-		data-env="production"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/current-loader/config-prod.html
+++ b/test/current-loader/config-prod.html
@@ -1,4 +1,1 @@
-<script src="../../bower_components/steal/steal.js"
-		data-main="main"
-		data-config ="config.js"
-		data-env="production"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/current-loader/prod.html
+++ b/test/current-loader/prod.html
@@ -1,4 +1,1 @@
-<script src="../../bower_components/steal/steal.js"
-		data-main="main"
-		data-config ="esconfig.js"
-		data-env="production"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/dep_plugins/prod.html
+++ b/test/dep_plugins/prod.html
@@ -1,5 +1,2 @@
 <div id="test-element">#test-element</div>
-<script src="../../bower_components/steal/steal.js"
-        data-main="main"
-        data-env="production"
-        data-config="./config.js"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/envs/prod.html
+++ b/test/envs/prod.html
@@ -1,1 +1,1 @@
-<script src="../../bower_components/steal/steal.js" env="window-production" config="./config.js" main="main"></script>
+<script src="./dist/steal.production.js" main="main"></script>

--- a/test/es_cjs/prod.html
+++ b/test/es_cjs/prod.html
@@ -1,4 +1,1 @@
-<script src="../../node_modules/steal/steal.js"
-	config="./package.json!npm"
-	env="production"
-	main="app/main"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/import-config/prod.html
+++ b/test/import-config/prod.html
@@ -1,5 +1,1 @@
-<script src="../../bower_components/steal/steal.js"
-		data-main="main"
-		data-base-url="./"
-		data-config="config.js"
-		data-env="production"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/json/prod.html
+++ b/test/json/prod.html
@@ -1,4 +1,1 @@
-<script src="../../node_modules/steal/steal.js"
-		env="production"
-		config="./package.json!npm"
-		main="jsontest/main"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/long_bundle_names/bundle.html
+++ b/test/long_bundle_names/bundle.html
@@ -1,5 +1,1 @@
-<script 
-	src="../../node_modules/steal/steal.js" 
-	data-base-url="./"
-	data-main="bundle"
-	data-env="production"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/meta_translate/prod.html
+++ b/test/meta_translate/prod.html
@@ -1,4 +1,1 @@
-<script src="../../bower_components/steal/steal.js"
-		data-main="main"
-		data-base-url="./"
-		data-env="production"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/multi-main/app_a.html
+++ b/test/multi-main/app_a.html
@@ -1,5 +1,1 @@
-<script 
-	src="../../node_modules/steal/steal.js" 
-	config="config.js"
-	main="app_a"
-	env="production"></script>
+<script src="./dist/steal.production.js" main="app_a"></script>

--- a/test/multi-main/app_b.html
+++ b/test/multi-main/app_b.html
@@ -1,5 +1,1 @@
-<script 
-	src="../../node_modules/steal/steal.js" 
-	config="config.js"
-	main="app_b"
-	env="production"></script>
+<script src="./dist/steal.production.js" main="app_b"></script>

--- a/test/multi-main/app_c.html
+++ b/test/multi-main/app_c.html
@@ -1,5 +1,1 @@
-<script 
-	src="../../node_modules/steal/steal.js" 
-	config="config.js"
-	main="app_c"
-	env="production"></script>
+<script src="./dist/steal.production.js" main="app_c"></script>

--- a/test/multi-main/app_d.html
+++ b/test/multi-main/app_d.html
@@ -1,5 +1,1 @@
-<script 
-	src="../../node_modules/steal/steal.js" 
-	config="config.js"
-	main="app_d"
-	env="production"></script>
+<script src="./dist/steal.production.js" main="app_d"></script>

--- a/test/multi-main/npm_app_a.html
+++ b/test/multi-main/npm_app_a.html
@@ -1,6 +1,1 @@
-<script 
-	src="../../node_modules/steal/steal.js" 
-	main="app_a"
-	base-url="dist"
-	bundles-path="bundles"
-	env="production"></script>
+<script src="./dist/steal.production.js" main="app_a"></script>

--- a/test/multi-main/npm_app_b.html
+++ b/test/multi-main/npm_app_b.html
@@ -1,6 +1,1 @@
-<script 
-	src="../../node_modules/steal/steal.js" 
-	main="app_b"
-	base-url="dist"
-	bundles-path="bundles"
-	env="production"></script>
+<script src="./dist/steal.production.js" main="app_b"></script>

--- a/test/multi-main/npm_app_c.html
+++ b/test/multi-main/npm_app_c.html
@@ -1,6 +1,1 @@
-<script 
-	src="../../node_modules/steal/steal.js" 
-	main="app_c"
-	base-url="dist"
-	bundles-path="bundles"
-	env="production"></script>
+<script src="./dist/steal.production.js" main="app_c"></script>

--- a/test/multi-main/npm_app_d.html
+++ b/test/multi-main/npm_app_d.html
@@ -1,6 +1,1 @@
-<script 
-	src="../../node_modules/steal/steal.js" 
-	main="app_d"
-	base-url="dist"
-	bundles-path="bundles"
-	env="production"></script>
+<script src="./dist/steal.production.js" main="app_d"></script>

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -25,6 +25,7 @@ describe("multi build", function(){
 				config: __dirname+"/bundle/stealconfig.js",
 				main: "bundle"
 			}, {
+				minify: false,
 				quiet: true
 			}).then(function(data){
 				var exists = fs.existsSync(  path.join(__dirname,"bundle/dist/bundles/bundle.js")  );
@@ -969,7 +970,6 @@ describe("multi build", function(){
 				}, close);
 
 			}, done);
-
 		});
 
 		it("work built", function(done){
@@ -1003,7 +1003,6 @@ describe("multi build", function(){
 					done(e);
 				});
 			});
-
 		});
 
 		it("work built using steal", function(done){
@@ -1604,6 +1603,7 @@ describe("multi build", function(){
 				return multiBuild({
 					baseURL: __dirname + "/npm-directories"
 				}, {
+					minify: false,
 					quiet: true
 				});
 			}).then(function(buildResult){

--- a/test/npm-directories/prod.html
+++ b/test/npm-directories/prod.html
@@ -1,4 +1,1 @@
-<script src="../../node_modules/steal/steal.js"
-	env="production"
-	data-config="./package.json!npm"
-	main="npm-dependencies/main.txt!npm-dependencies/plug"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/npm-multi-main/app_a.html
+++ b/test/npm-multi-main/app_a.html
@@ -1,5 +1,1 @@
-<script
-        src="../../node_modules/steal/steal.js"
-        main="multi-main/app_a"
-        config="./package.json!npm"
-        env="window-production"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/npm/prod.html
+++ b/test/npm/prod.html
@@ -1,6 +1,1 @@
-<body>
-	<script src='./node_modules/steal/steal.js'
-		data-env="production"
-		data-main="npm-test/main"></script>
-</body>
-
+<script src="./dist/steal.production.js"></script>

--- a/test/plugins/prod.html
+++ b/test/plugins/prod.html
@@ -1,6 +1,2 @@
 <div id="main"></div>
-<script src="../../bower_components/steal/steal.js"
-        data-main="main"
-        data-config="./config.js"
-        data-env="production"
-        ></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/progressive_package/prod.html
+++ b/test/progressive_package/prod.html
@@ -1,3 +1,1 @@
-<script src="../../node_modules/steal/steal.js"
-env="window-production"
-config="package.json!npm" main="app/main"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/side_bundle/prod.html
+++ b/test/side_bundle/prod.html
@@ -1,4 +1,1 @@
-<script src="../../node_modules/steal/steal.js"
-	data-env="production"
-	data-config="./package.json!npm"
-	data-main="ignore_true/main"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/side_bundle_dep/prod.html
+++ b/test/side_bundle_dep/prod.html
@@ -1,4 +1,1 @@
-<script src="../../node_modules/steal/steal.js"
-	data-env="production"
-	data-config="./package.json!npm"
-	data-main="side/main"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/virtual/prod.html
+++ b/test/virtual/prod.html
@@ -1,4 +1,1 @@
-<script src="../../bower_components/steal/steal.js"
-	data-config="config.js"
-	data-main="main"
-	data-env="production"></script>
+<script src="./dist/steal.production.js"></script>

--- a/test/write_stream_test.js
+++ b/test/write_stream_test.js
@@ -23,7 +23,8 @@ describe("streams.write", function(){
 				.pipe(s.minify())
 				.pipe(s.bundle())
 				.pipe(s.concat())
-				.pipe(s.write());
+				.pipe(s.write())
+				.pipe(s.steal());
 
 			buildStream.pipe(through.obj(function(data){
 				open("test/bundle/bundle.html#a",function(browser, close){


### PR DESCRIPTION
This writes out a configured steal.production.js into the user's `dest`
folder. This allows using Steal in production with just:

```html
<script src="./dist/steal.production.js"></script>
```

Closes #531