### PR TITLE
Export: better error messaging on removed options

### DIFF
--- a/lib/build/export.js
+++ b/lib/build/export.js
@@ -225,6 +225,18 @@ module.exports = function(config, defaults, modules){
 
 		};
 
+		if(!config.steal) {
+			var message;
+			if(config.system) {
+				message = "The 'system' option was removed in 1.0, use 'steal' instead: http://stealjs.com/docs/steal-tools.export.object.html";
+			} else {
+				message = "A 'steal' option is required.";
+			}
+			reject(new Error(message));
+			return;
+		}
+
+
 		fileWrites++;
 		transformImport(config.steal, config.options).then(function(configPluginify){
 			fileWrites--;

--- a/test/export_test.js
+++ b/test/export_test.js
@@ -191,6 +191,36 @@ describe("export", function(){
 		}, done);
 	});
 
+	it("Gives an error if using the 'system' property that was removed in 1.0", function(done){
+		stealExport({
+			system:{},
+			options: {},
+			outputs: {}
+		})
+		.then(function(){
+			assert.ok(false, "This should have failed");	
+		}, function(err){
+			var correctError = /'system' option/.test(err.message);
+			assert.ok(correctError, "Logs that the system option was removed");
+		})
+		.then(done, done);
+	});
+
+	it("Gives an error if 'steal' option is missing", function(done){
+		stealExport({
+			options: {},
+			outputs: {}
+		})
+		.then(function(){
+			assert.ok(false, "This should have failed");	
+		}, function(err){
+			var correctError = /'steal' option/.test(err.message);
+			assert.ok(correctError, "Logs that steal is required");
+		})
+		.then(done, done);
+	});
+
+
 	describe("eachModule", function(){
 		it("works", function(done){
 			stealExport({


### PR DESCRIPTION
This improves the error messaging when omitting the `'steal'` option
which is required for configuration. If 'system' is used we log an error
that it has been replaced by 'steal'.

Closes #557