### PR TITLE
Breaking test with multiple `define` calls.  

### DIFF
--- a/lib/graph/make_graph.js
+++ b/lib/graph/make_graph.js
@@ -3,7 +3,7 @@ var trace = require("../trace");
 var steal = require("steal");
 var _ = require("lodash");
 var clone = _.cloneDeep;
-var addParseAMD = require("system-parse-amd");
+var addParseAMD = require("steal-parse-amd");
 
 var formatMap = {
 	'amd-parse' : 'amd'

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "bitovi-source-map": "0.4.2-bitovi.2",
     "steal": "^1.0.1",
     "steal-bundler": "^0.3.0",
-    "system-parse-amd": "0.0.2",
+    "steal-parse-amd": "^1.0.0",
     "through2": "^2.0.0",
     "tmp": "0.0.26",
     "traceur": "0.0.91",

--- a/test/bundle_name_test.js
+++ b/test/bundle_name_test.js
@@ -143,10 +143,10 @@ describe("bundle name without npm package", function() {
 	});
 
 	it("only return names with chars, numbers and -", function() {
-		bundle = {
+		var bundle = {
 			bundles: ["main/bar0815.com.js", "bar/foo- bar"]
 		};
-		bundleName = nameBundle.getName(bundle);
+		var bundleName = nameBundle.getName(bundle);
 		assert.equal(bundleName, dirName + 'bar0815-com-foo-bar');
 	});
 

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -2215,7 +2215,7 @@ describe("multi build", function(){
 		});
 	});
 
-	it.only("should work with UMD produced by webpack (#579)", function(done){
+	it("should work with UMD produced by webpack (#579)", function(done){
 		rmdir(__dirname + "/umd/bundle", function(error){
 			if(error) {
 				return done(error);

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -27,7 +27,7 @@ describe("multi build", function(){
 			}, {
 				minify: false,
 				quiet: true
-			}).then(function(data){
+			}).then(function(){
 				var exists = fs.existsSync(  path.join(__dirname,"bundle/dist/bundles/bundle.js")  );
 				if(!exists) {
 					done(new Error("no bundle info"));
@@ -213,7 +213,7 @@ describe("multi build", function(){
 
 		rmdir(__dirname+"/bundle/bundles", function(error){
 			if(error){
-				done(error)
+				done(error);
 			}
 
 			multiBuild({
@@ -223,7 +223,7 @@ describe("multi build", function(){
 				bundleSteal: true,
 				quiet: true,
 				minify: false
-			}).then(function(data){
+			}).then(function(){
 
 				open("test/bundle/packaged_steal.html#a",function(browser, close){
 					find(browser,"appA", function(appA){
@@ -256,7 +256,7 @@ describe("multi build", function(){
 
 		rmdir(__dirname+"/bundle/alternate", function(error){
 			if(error){
-				done(error)
+				done(error);
 			}
 
 			multiBuild({
@@ -267,7 +267,7 @@ describe("multi build", function(){
 				dest: __dirname + "/bundle/alternate",
 				quiet: true,
 				minify: false
-			}).then(function(data){
+			}).then(function(){
 
 				open("test/bundle/folder/packaged_steal.html#a",function(browser, close){
 					find(browser,"appA", function(appA){
@@ -301,7 +301,7 @@ describe("multi build", function(){
 
 		rmdir(__dirname+"/dist", function(error){
 			if(error){
-				done(error)
+				done(error);
 			}
 
 			multiBuild({
@@ -310,7 +310,7 @@ describe("multi build", function(){
 			}, {
 				quiet: true,
 				minify: false
-			}).then(function(data){
+			}).then(function(){
 				open("test/basics/prod.html",function(browser, close){
 					find(browser,"MODULE", function(module){
 						assert(true, "module");
@@ -338,7 +338,7 @@ describe("multi build", function(){
 	it("System.instantiate works when bundling steal", function(done){
 		rmdir(__dirname+"/dist", function(error){
 			if(error){
-				return done(error)
+				return done(error);
 			}
 
 			multiBuild({
@@ -348,9 +348,9 @@ describe("multi build", function(){
 				bundleSteal: true,
 				quiet: true,
 				minify: false
-			}).then(function(data){
+			}).then(function(){
 				open("test/basics/prod-inst.html",function(browser, close){
-					find(browser,"MODULE", function(module){
+					find(browser,"MODULE", function(){
 						assert(true, "module");
 
 						// We marked stealconfig.js as instantiated so it shouldn't have it's properties
@@ -501,7 +501,7 @@ describe("multi build", function(){
 	it("works with an unnormalized main", function(done){
 		rmdir(__dirname+"/dist", function(error){
 			if(error){
-				done(error)
+				done(error);
 			}
 
 			multiBuild({
@@ -510,7 +510,7 @@ describe("multi build", function(){
 			}, {
 				quiet: true,
 				minify: false
-			}).then(function(data){
+			}).then(function(){
 				open("test/basics/prod.html",function(browser, close){
 					find(browser,"MODULE", function(module){
 						assert(true, "module");
@@ -615,7 +615,7 @@ describe("multi build", function(){
 					minify: false
 				}).then(function(){
 					open("test/side_bundle/prod.html", function(browser, close){
-						find(browser, "MODULE", function(module){
+						find(browser, "MODULE", function(){
 							var loader = browser.window.System;
 
 							comparify(loader.bundles, {
@@ -640,7 +640,7 @@ describe("multi build", function(){
 					minify: false
 				}).then(function(){
 					open("test/side_bundle_dep/prod.html", function(browser, close){
-						find(browser, "MODULE", function(module){
+						find(browser, "MODULE", function(){
 							var loader = browser.window.System;
 
 							comparify(loader.bundles, {
@@ -818,7 +818,7 @@ describe("multi build", function(){
 			rmdir(__dirname+"/plugins/dist/bundles", function(error){
 
 				if(error){
-					done(error)
+					done(error);
 				}
 				// build the project that
 				// uses a plugin
@@ -828,7 +828,7 @@ describe("multi build", function(){
 					main: "main"
 				}, {
 					quiet: true
-				}).then(function(data){
+				}).then(function(){
 					// open the prod page and make sure
 					// the plugin processed the input correctly
 					open("test/plugins/prod.html", function(browser, close){
@@ -851,7 +851,7 @@ describe("multi build", function(){
 			rmdir(__dirname+"/plugins/dist", function(error){
 
 				if(error){
-					done(error)
+					done(error);
 				}
 
 				// build the project that
@@ -864,7 +864,7 @@ describe("multi build", function(){
 					}
 				}, {
 					quiet: true
-				}).then(function(data){
+				}).then(function(){
 					// open the prod page and make sure
 					// the plugin processed the input correctly
 					open("test/plugins/prod-steal.html", function(browser, close){
@@ -949,7 +949,7 @@ describe("multi build", function(){
 
 			rmdir(__dirname+"/multi-main/dist", function(error){
 				if(error){
-					done(error)
+					done(error);
 				}
 
 				multiBuild({
@@ -958,7 +958,7 @@ describe("multi build", function(){
 				}, {
 					quiet: true
 					//verbose: true
-				}).then(function(data){
+				}).then(function(){
 
 					var checkNext = function(next){
 						if(next) {
@@ -978,7 +978,7 @@ describe("multi build", function(){
 									var mynext = mains.shift();
 									if(mynext) {
 										setTimeout(function(){
-											checkNext(mynext)
+											checkNext(mynext);
 										},1);
 									} else {
 										done();
@@ -1030,7 +1030,7 @@ describe("multi build", function(){
 				}, {
 					quiet: true,
 					minify: false
-				}).then(function(data){
+				}).then(function(){
 
 					var checkNext = function(next){
 						if(next) {
@@ -1050,7 +1050,7 @@ describe("multi build", function(){
 									var mynext = mains.shift();
 									if(mynext) {
 										setTimeout(function(){
-											checkNext(mynext)
+											checkNext(mynext);
 										},1);
 									} else {
 										done();
@@ -1090,7 +1090,7 @@ describe("multi build", function(){
 
 			rmdir(__dirname+"/multi-main/dist", function(error){
 				if(error){
-					done(error)
+					done(error);
 				}
 
 				multiBuild({
@@ -1100,7 +1100,7 @@ describe("multi build", function(){
 					bundleSteal: true,
 					quiet: true,
 					minify: false
-				}).then(function(data){
+				}).then(function(){
 					var checkNext = function(next){
 						if(next) {
 							open("test/multi-main/bundle_"+next+".html",function(browser, close){
@@ -1119,7 +1119,7 @@ describe("multi build", function(){
 									var mynext = mains.shift();
 									if(mynext) {
 										setTimeout(function(){
-											checkNext(mynext)
+											checkNext(mynext);
 										},1);
 									} else {
 										done();
@@ -1143,7 +1143,7 @@ describe("multi build", function(){
 
 			rmdir(__dirname+"/current-loader/dist", function(error){
 				if(error){
-					done(error)
+					done(error);
 				}
 				// build the project that uses @loader
 				multiBuild({
@@ -1175,7 +1175,7 @@ describe("multi build", function(){
 
 			rmdir(__dirname+"/current-loader/dist", function(error){
 				if(error){
-					done(error)
+					done(error);
 				}
 				// build the project that uses @loader
 				multiBuild({
@@ -1206,7 +1206,7 @@ describe("multi build", function(){
 		it("works with es6", function(done) {
 			rmdir(__dirname+"/current-loader/dist", function(error){
 				if(error){
-					done(error)
+					done(error);
 				}
 				// build the project that uses @loader
 				multiBuild({
@@ -1251,9 +1251,9 @@ describe("multi build", function(){
 					}, {
 						dest: __dirname + "/bundle_multiple_builds",
 						quiet: true
-					})
+					});
 
-				Promise.all([first, second]).then(function(data){
+				Promise.all([first, second]).then(function(){
 					done();
 				}).catch(done);
 			});
@@ -1318,7 +1318,7 @@ describe("multi build", function(){
 					minify: false,
 					quiet: true
 				});
-			}).then(function(buildResult){
+			}).then(function(){
 				done();
 			}, done);
 		});
@@ -1394,7 +1394,7 @@ describe("multi build", function(){
 
 								if(error){ return done(error); }
 
-								done()
+								done();
 
 							});
 
@@ -1497,7 +1497,7 @@ describe("multi build", function(){
 					quiet: true,
 					minify: false,
 					//bundleSteal: true
-				}).then(function(data){
+				}).then(function(){
 
 					open("test/npm-multi-main/app_a.html",function(browser, close){
 						find(browser,"app", function(app){
@@ -1528,7 +1528,7 @@ describe("multi build", function(){
 					quiet: true,
 					minify: false,
 					//bundleSteal: true
-				}).then(function(data){
+				}).then(function(){
 					open("test/npm-multi-main/app_b.html",function(browser, close){
 						find(browser,"app", function(app){
 							assert(true, "app found");
@@ -1558,7 +1558,7 @@ describe("multi build", function(){
 				}, {
 					quiet: true,
 					minify: false,
-				}).then(function(data){
+				}).then(function(){
 
 					open("test/npm-multi-main/app_c.html",function(browser, close){
 						find(browser,"app", function(app){
@@ -1589,7 +1589,7 @@ describe("multi build", function(){
 				}, {
 					quiet: true,
 					minify: false
-				}).then(function(data){
+				}).then(function(){
 
 					var mains = ["multi-main/app_a", "multi-main/app_b", "multi-main/app_c"];
 
@@ -1612,7 +1612,7 @@ describe("multi build", function(){
 									var mynext = mains.shift();
 									if(mynext) {
 										setTimeout(function(){
-											checkNext(mynext)
+											checkNext(mynext);
 										},1);
 									} else {
 										done();
@@ -1643,7 +1643,7 @@ describe("multi build", function(){
 					quiet: true,
 					minify: false,
 					bundleSteal: true
-				}).then(function(data){
+				}).then(function(){
 
 					var mains = ["multi-main/app_a", "multi-main/app_b"];
 
@@ -1666,7 +1666,7 @@ describe("multi build", function(){
 									var mynext = mains.shift();
 									if(mynext) {
 										setTimeout(function(){
-											checkNext(mynext)
+											checkNext(mynext);
 										},1);
 									} else {
 										done();
@@ -1826,7 +1826,7 @@ describe("multi build", function(){
 
 					// in production config this module should map to @empty if it is not needed
 					// a feature can be, steal set automaticly @empty if the module is set with bundles:false in package.json
-					assert.equal(data.loader.envs['window-production'].map.jqueryt, '@empty', 'ignore modules must declare as @empty')
+					assert.equal(data.loader.envs['window-production'].map.jqueryt, '@empty', 'ignore modules must declare as @empty');
 
 					// bundle exists
 					assert.ok(fs.existsSync(__dirname + "/bundle_false/dist/bundles/src/main.js"), "bundle main");
@@ -1967,7 +1967,7 @@ describe("multi build", function(){
 		it("should work", function(done){
 			rmdir(__dirname+"/long_bundle_names/dist", function(error){
 				if(error){
-					done(error)
+					done(error);
 				}
 
 				multiBuild({
@@ -1975,7 +1975,7 @@ describe("multi build", function(){
 					main: "bundle"
 				}, {
 					quiet: true
-				}).then(function(data){
+				}).then(function(){
 					open("test/long_bundle_names/bundle.html#a",function(browser, close){
 						find(browser,"appA", function(appA){
 								assert(true, "got A");
@@ -1995,7 +1995,7 @@ describe("multi build", function(){
 		it("should truncate and hash long bundle names", function(done){
 			rmdir(__dirname+"/long_bundle_names/dist", function(error){
 				if(error){
-					done(error)
+					done(error);
 				}
 
 				multiBuild({
@@ -2003,7 +2003,7 @@ describe("multi build", function(){
 					main: "bundle"
 				}, {
 					quiet: true
-				}).then(function(data){
+				}).then(function(){
 
 					assert(fs.existsSync("test/long_bundle_names/dist/bundles/app_a_with_a_ver-5797ef41.js"));
 					assert(fs.existsSync("test/long_bundle_names/dist/bundles/app_a_with_a_ver-8702980e.js"));
@@ -2042,7 +2042,7 @@ describe("multi build", function(){
 					quiet: true,
 					sourceMaps: true,
 					minify: true
-				}).then(function(data){
+				}).then(function(){
 					var exists = fs.existsSync(path.join(__dirname,"dist/bundles/basics/basics.js.map"));
 					if(!exists) {
 						done(new Error("no bundle info"));
@@ -2116,21 +2116,21 @@ describe("multi build", function(){
 				})
 				.then(function () {
 					var source = fs.readFileSync(__dirname + "/strip-sourcemap/dist/bundles/main.js", "utf8");
-					var soureMapRegex = /\/\/# sourceMappingURL=main.js.map/m;
+					//var soureMapRegex = /\/\/# sourceMappingURL=main.js.map/m;
 					assert.ok(/\/\/# sourceMappingURL=main.js.map/m.test(source), 'sourceMap found');
 
 					assert.ok(!/\/\/# sourceMappingURL=foobar.js.map/m.test(source), 'foobar.js.map should not be found');
 					assert.ok(!/\/\/# sourceMappingURL=Promise.js.map/m.test(source), 'foobar.js.map should not be found');
 				})
 				.then(done, done);
-		})
+		});
 	});
 
 	describe("multi-main with bundled steal", function(){
 		it("set main automatically", function(done){
 			rmdir(__dirname+"/multi-main-bundled/dist", function(error){
 				if(error){
-					done(error)
+					done(error);
 				}
 
 				multiBuild({
@@ -2143,7 +2143,7 @@ describe("multi build", function(){
 					bundleSteal: true,
 					quiet: true,
 					minify: false
-				}).then(function(data){
+				}).then(function(){
 					open("test/multi-main-bundled/bundle_app_a.html",function(browser, close){
 						find(browser,"app", function(app){
 							assert(true, "got app");
@@ -2214,4 +2214,28 @@ describe("multi build", function(){
 			});
 		});
 	});
+
+	it.only("should work with UMD produced by webpack (#579)", function(done){
+		rmdir(__dirname + "/umd/bundle", function(error){
+			if(error) {
+				return done(error);
+			}
+
+			multiBuild({
+				config: __dirname + "/umd/config.js",
+				main: "main"
+			}, {
+				quiet: true
+			}).then(function(){
+				open("test/umd/prod.html", function(browser, close){
+					find(browser, "umdExport", function(umdExport){
+						assert.equal(typeof umdExport, "function", "got umdExport");
+						close();
+					}, close);
+				}, done);
+			}).catch(done);
+		});
+	});
+
+
 });

--- a/test/umd/dev.html
+++ b/test/umd/dev.html
@@ -1,0 +1,1 @@
+<script src="../../node_modules/steal/steal.js" config="config.js" main="main"></script>

--- a/test/umd/main.js
+++ b/test/umd/main.js
@@ -1,0 +1,3 @@
+var umdExport = require('umd-ish');
+
+window.umdExport = umdExport;

--- a/test/umd/prod.html
+++ b/test/umd/prod.html
@@ -1,0 +1,1 @@
+<script src="./dist/steal.production.js"></script>

--- a/test/umd/umd-ish.js
+++ b/test/umd/umd-ish.js
@@ -1,0 +1,91 @@
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports["io"] = factory();
+	else
+		root["io"] = factory();
+})(this, function() {
+return /******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId])
+/******/ 			return installedModules[moduleId].exports;
+
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			exports: {},
+/******/ 			id: moduleId,
+/******/ 			loaded: false
+/******/ 		};
+
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+
+/******/ 		// Flag the module as loaded
+/******/ 		module.loaded = true;
+
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+
+
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ function(module, exports, __webpack_require__) {
+
+	module.exports = exports = lookup;
+
+
+	function lookup(uri, opts) {
+
+	}
+
+/***/ },
+/* 11 */
+/***/ function(module, exports, __webpack_require__) {
+
+	/* WEBPACK VAR INJECTION */(function(module, global) {/*** IMPORTS FROM imports-loader ***/
+	var define = false;
+
+	/*! JSON v3.3.2 | http://bestiejs.github.io/json3 | Copyright 2012-2014, Kit Cambridge | http://kit.mit-license.org */
+	;(function () {
+	  // Detect the `define` function exposed by asynchronous module loaders. The
+	  // strict `define` check is necessary for compatibility with `r.js`.
+	  var isLoader = typeof define === "function" && define.amd;
+
+	  // Export for asynchronous module loaders.
+	  if (isLoader) {
+	    define(function () {
+	      return JSON3;
+	    });
+	  }
+	}).call(this);
+
+
+	/* WEBPACK VAR INJECTION */}.call(exports, __webpack_require__(12)(module), (function() { return this; }())))
+
+/***/ }])
+});
+;
+//# sourceMappingURL=socket.io.js.map


### PR DESCRIPTION
Adds a test that shows a umd build with nested define calls breaks for #579.  This also lints a bit of the test code.


The `main` problem is this second `define` in _umd-ish.js_ that looks like:

```
	  if (isLoader) {
	    define(function () {
	      return JSON3;
	    });
	  }
```

I'm not sure what the best solution is without doing a lot of code analysis.  

My thought is that we could still give people a warning, but choose the `define` call with the most deps ... or the one that is the "least" nested as UMD factory functions will typically call `define` within only one other `function{ .... }`.