### PR TITLE
Support JS minification through custom function

### DIFF
--- a/doc/types/build-options.md
+++ b/doc/types/build-options.md
@@ -3,7 +3,38 @@
 
 Options used to configure the build process.
 
-@option {Boolean} [minify=true] Sets whether the source code is minified prior to writing.
+@option {Boolean|Function} [minify=true] 
+
+**Boolean**
+
+Sets whether the source code is minified prior to writing.
+
+Minification is optional but on by default, you can turn it off by doing:
+
+```javascript
+stealtools.build(config, {
+	minify: false
+});
+```
+---
+**Function**
+
+A function can be provided to handle minification of each file in a bundle, e.g:
+
+```javascript
+stealtools.build(config, {
+	minify: function(source, options) {
+		// use your own library to minify source.code 
+		source.code = doCustomMinification(source.code);
+
+		// return the source object when minification is complete
+		return source;
+	}
+});
+```
+
+The function takes a `source` object as the first parameter, this object contains the `code` and its AST version after the transpilation
+process; the second parameter, `options`, is the [steal-tools.BuildOptions] object passed to configure the build process.
 
 @option {Boolean} [bundleSteal=false] Sets whether StealJS will be included in the built file. Enabling this option will allow you to limit the initial request to just one script.
 

--- a/lib/build/multi.js
+++ b/lib/build/multi.js
@@ -79,8 +79,6 @@ module.exports = function(config, options){
 		return continuousBuild(config, options);
 
 	} else {
-		// Minification is optional, but on by default
-		options.minify = options.minify !== false;
 		try {
 			options = assignDefaultOptions(config, options);
 		} catch(err) {
@@ -113,7 +111,7 @@ module.exports = function(config, options){
 						.then(function(){
 							resolve(data);
 						}, function(err){
-							reject(err);	 
+							reject(err);
 						});
 					return;
 				}

--- a/lib/buildTypes/minifyJS.js
+++ b/lib/buildTypes/minifyJS.js
@@ -1,21 +1,30 @@
-var UglifyJS = require("uglify-js");
+var isFunction = require("lodash").isFunction;
 
-module.exports = function(source, options){
-	var opts = (options != null) ? options.uglifyOptions : {};
+module.exports = function(source, options) {
+	return (isFunction(options.minify)) ?
+		options.minify(source, options) :
+		uglify(source, options);
+};
+
+function uglify(source, options) {
+	var UglifyJS = require("uglify-js");
+
 	var code = source.code;
+	var opts = (options != null) ? options.uglifyOptions : {};
 
 	opts = opts || {};
 	opts.fromString = true;
-	if(source.map) {
+
+	if (source.map) {
 		var inMap = source.map.toJSON();
 		var file = inMap.sources && inMap.sources[0];
 		opts.inSourceMap = inMap;
 		opts.outSourceMap = file;
 
-		if(options.sourceMapsContent) {
+		if (options.sourceMapsContent) {
 			opts.sourceMapIncludeSources = true;
 		}
 	}
 
 	return UglifyJS.minify(code, opts);
-};
+}

--- a/lib/stream/minify.js
+++ b/lib/stream/minify.js
@@ -18,8 +18,11 @@ function minify(data){
 	var configuration = data.configuration;
 	var options = configuration.options;
 
+	// Minification is optional, but on by default
+	var shouldMinifyFiles = options.minify !== false;
+
 	// Minify every file in the graph
-	if(options.minify) {
+	if (shouldMinifyFiles) {
 		winston.info("Minifying...");
 		minifyGraph(dependencyGraph, options);
 		minifyGraph(data.configGraph, options);

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -2229,7 +2229,7 @@ describe("multi build", function(){
 			}).then(function(){
 				open("test/umd/prod.html", function(browser, close){
 					find(browser, "umdExport", function(umdExport){
-						assert.equal(typeof umdExport, "function", "got umdExport");
+                        assert.equal(typeof umdExport, "function", "got umdExport");
 						close();
 					}, close);
 				}, done);
@@ -2237,5 +2237,31 @@ describe("multi build", function(){
 		});
 	});
 
+	it("supports JS minification through custom function", function() {
+		function customMinify(source, options) {
+			assert.ok(source.code, "gets the source code");
+			assert.ok(options, "gets the options object");
 
+			source.code = "custom minification works!!";
+			return source;
+		}
+
+		return asap(rmdir)("test/basics/dist")
+			.then(function() {
+				return multiBuild({
+					config: path.join(__dirname, "stealconfig.js"),
+					main: "basics/basics"
+				}, {
+					minify: customMinify
+				});
+			})
+			.then(function() {
+				var source = fs.readFileSync(
+					path.join(__dirname, "dist", "bundles", "basics", "basics.js")
+				);
+
+				assert.ok(/custom minification works/.test(source),
+					"code was changed by custom minifier");
+			});
+	});
 });


### PR DESCRIPTION
Closes #524 

I tried this change using the custom build script below and it worked as expected!

The issue I see in this example is that babili gets the code after it has been transpiled, so we are not taking advantage of babili's Babili ES2015+ goodness 

```javascript
var path = require('path');
var babel = require('babel-core');
var stealTools = require('steal-tools');
var babiliPreset = require('babel-preset-babili');

var config = {
  config: path.join(__dirname, 'package.json!npm')
};

var options = {
  minify: function(source) {
    return babel.transform(source.code, {
      presets: [ babiliPreset ],
      sourceMaps: false,
      babelrc: false
    });
  }
};

stealTools.build(config, options)
  .then(function() {
    console.log('DONE!');
  })
  .catch(function() {
    console.log('FAILED: ', arguments[0]);
  });
```