### PR TITLE
Upgrade to transpile 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "through2": "^2.0.0",
     "tmp": "0.0.31",
     "traceur": "0.0.91",
-    "transpile": "^1.0.0",
+    "transpile": "^2.0.0",
     "uglify-js": "~2.7.5",
     "urix": "^0.1.0",
     "winston": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "moment": "^2.10.2",
     "pdenodeify": "^0.1.0",
     "bitovi-source-map": "0.4.2-bitovi.2",
-    "steal": "^1.0.1",
+    "steal": "^1.2.1",
     "steal-bundler": "^0.3.0",
     "steal-parse-amd": "^1.0.0",
     "through2": "^2.0.0",
@@ -82,6 +82,11 @@
         }
       },
       "^6.0.0": {
+        "devDependencies": {
+          "zombie": "^4.2.1"
+        }
+      },
+      "^7.0.0": {
         "devDependencies": {
           "zombie": "^4.2.1"
         }


### PR DESCRIPTION
Upgrading to transpile 2.0 will allow the globals configuration to work
properly.