### PR TITLE
Allow steal-tools to build arbitrary buildTypes

### DIFF
--- a/lib/bundle/concat_source.js
+++ b/lib/bundle/concat_source.js
@@ -55,7 +55,11 @@ module.exports = function(bundle, sourceProp, excludePlugins){
 	bundle.source = result;
 
 	function prependName(node, file) {
-		if(node.prependModuleName !== false && file.node.load.name) {
+		var load = file.node.load;
+		var prepend = node.prependModuleName !== false && load.name &&
+			load.metadata.prependModuleName !== false;
+
+		if(prepend) {
 			node.prepend("/*"+file.node.load.name+"*/\n");
 		}
 	}

--- a/lib/graph/minify.js
+++ b/lib/graph/minify.js
@@ -4,22 +4,23 @@ var minifyJS = require('../buildTypes/minifyJS'),
 
 function minify(node, options) {
 	transformActiveSource(node,"minify-true", function(node, source){
-		var buildType = node.load.metadata.buildType;
+		var buildType = node.load.metadata.buildType || "js";
 
-		// skip css source files, css is minified after the bundle is concatenated
-		if(buildType === "css") {
-			return source;
-		} else {
+		if(buildType === "js") {
 			var result;
 			try {
-				result = minifyJS(source, options);	
+				result = minifyJS(source, options);
 			} catch(e) {
 				winston.warn("Error occured while minifying " + node.load.address +
 							 "\n" + e.message + "\nLine: " + e.line + "\nCol: " + e.col + "\nPos: " + e.pos);
 				throw(e);
 			}
-			
+
 			return result;
+		}
+		// skip css source files, css is minified after the bundle is concatenated
+		else {
+			return source;
 		}
 	});
 }

--- a/test/build_types/config.js
+++ b/test/build_types/config.js
@@ -1,0 +1,5 @@
+steal.config({
+	ext: {
+		html: "plugin-html"
+	}
+})

--- a/test/build_types/main.css
+++ b/test/build_types/main.css
@@ -1,4 +1,0 @@
-#test-element {
-	width: 50px;
-	background-color: yellow;
-}

--- a/test/build_types/main.js
+++ b/test/build_types/main.js
@@ -1,16 +1,3 @@
-import 'main.css!';
+require("./template.html");
 
-function getFile(url, cb) {
-	var xhr = new XMLHttpRequest();              
-	xhr.open("GET", url, true);                             
-	xhr.send(null);
-	xhr.onreadystatechange = function(){
-		if(xhr.readyState === 4) {
-			cb(xhr.responseText);
-		}
-	};                                       
-}
-
-getFile(document.getElementsByTagName('link')[0].href, function(content){
-	window.STYLE_CONTENT =  content;
-});
+window.ELEMENT = document.getElementById("main");

--- a/test/build_types/plugin-html.js
+++ b/test/build_types/plugin-html.js
@@ -1,0 +1,28 @@
+function getDocument() {
+	if(typeof document !== "undefined")
+		return document;
+}
+
+exports.instantiate = function(load){
+	var doc = getDocument();
+	if(doc) {
+		var frag = document.createDocumentFragment();
+		var div = document.createElement("div");
+		div.innerHTML = load.source;
+		var node = div.firstChild, next;
+		while(node) {
+			next = node.nextSibling;
+			frag.appendChild(node);
+			node = next;
+		}
+	}
+	load.metadata.prependModuleName = false;
+	load.metadata.deps = [];
+	load.metadata.format = "html";
+	load.metadata.execute = function(){
+		doc.body.appendChild(frag);
+	};
+};
+
+exports.buildType = "html";
+exports.includeInBuild = true;

--- a/test/build_types/prod.html
+++ b/test/build_types/prod.html
@@ -1,2 +1,8 @@
-<div id="test-element">#test-element</div>
+<html>
+<head>
+	<title>Test</title>
+</head>
+<body>
 <script src="./dist/steal.production.js"></script>
+</body>
+</html>

--- a/test/build_types/template.html
+++ b/test/build_types/template.html
@@ -1,0 +1,1 @@
+<div id="main">Hello world!</div>

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -2367,4 +2367,25 @@ describe("multi build", function(){
 				assert.ok(!err, err.stack || err);
 			});
 	});
+
+	it("can build out buildTypes it is not aware of", function(done){
+		var buildTypesDir = path.join(__dirname, "build_types");
+		asap(rmdir)(path.join(buildTypesDir, "dist"))
+		.then(function(){
+			return multiBuild({
+				config: path.join(buildTypesDir, "config.js"),
+				main: "main"
+			}, {quiet: true});
+		})
+		.then(function(){
+			var page = path.join("test", "build_types", "prod.html");
+
+			open(page, function(browser, close){
+				find(browser, "ELEMENT", function(el){
+					assert.equal(el.id, "main", "element inserted");
+					done();
+				}, close);
+			}, done);
+		})
+	});
 });


### PR DESCRIPTION
This allows steal-tools to build arbitrary buildTypes. Basically it just
doesn't try to minify buildTypes it doesn't understand or add the
moduleName comment.

Fixes #586