### PR TITLE
support for envify in the default minify function

### DIFF
--- a/lib/buildTypes/minifyJS.js
+++ b/lib/buildTypes/minifyJS.js
@@ -7,8 +7,9 @@ module.exports = function(source, options) {
 };
 
 function uglify(source, options) {
+	var envify = require("loose-envify/replace");
 	var UglifyJS = require("uglify-js");
-
+	
 	var code = source.code;
 	var opts = (options != null) ? options.uglifyOptions : {};
 
@@ -24,6 +25,10 @@ function uglify(source, options) {
 		if (options.sourceMapsContent) {
 			opts.sourceMapIncludeSources = true;
 		}
+	}
+
+	if(options.envify) {
+		code = envify(code, [process.env]);
 	}
 
 	return UglifyJS.minify(code, opts);

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -27,6 +27,11 @@ module.exports = {
 		type: "boolean",
 		describe: "Do not minify the output"
 	},
+	envify: {
+		type: "boolean",
+		default: false,
+		describe: "Enables envify during minification. Defaults to false"
+	},
 	watch: {
 		alias: "w",
 		type: "boolean",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "glob": "^7.1.1",
     "is-appveyor": "^1.0.0",
     "lodash": "^4.3.0",
+    "loose-envify": "^1.3.1",
     "moment": "^2.10.2",
     "multimatch": "^2.1.0",
     "pdenodeify": "^0.1.0",

--- a/test/minify/minify.js
+++ b/test/minify/minify.js
@@ -6,4 +6,8 @@ var thisObjectHasABigName = {
 	foo: "bar"
 };
 
+if(process.env.ENVIFY_VAR !== "test_value") { 
+	thisObjectHasABigName.envifyTest = "when envify is turned on this should be removed"; 
+}
+
 module.exports = thisObjectHasABigName;

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -143,7 +143,43 @@ describe("multi build", function(){
 				var hasLongVariable = actualJS.indexOf("thisObjectHasABigName") !== -1;
 				var hasGlobalLongVariable = actualJS.indexOf("anotherVeryLongName") !== -1;
 				var hasDevCode = actualJS.indexOf("remove this") !== -1;
+				var hasEnvifyCode = actualJS.indexOf("when envify is turned on this should be removed") !== -1;
 
+				assert(hasEnvifyCode, "Minified source has envify test code removed.");
+				assert(!hasDevCode, "Minified source has dev code removed.");
+				assert(!hasLongVariable, "Minified source renamed long variable.");
+				assert(!hasGlobalLongVariable, "Minified source includes a global that was minified.");
+			});
+	});
+
+	it("should allow turning envify on", function() {
+		var config = {
+			config: path.join(__dirname, "minify", "config.js"),
+			main: "minify"
+		};
+
+		var options = {
+			quiet: true,
+			envify: true
+		};
+
+		return asap(rmdir)(path.join(__dirname, "minify", "dist"))
+			.then(function() {
+				process.env.ENVIFY_VAR = "test_value";
+				return multiBuild(config, options);
+			})
+			.then(function() {
+				delete process.env.ENVIFY_VAR;
+
+				var main = path.join(__dirname, "minify", "dist", "bundles", "minify.js");
+				var actualJS = fs.readFileSync(main, "utf8");
+
+				var hasLongVariable = actualJS.indexOf("thisObjectHasABigName") !== -1;
+				var hasGlobalLongVariable = actualJS.indexOf("anotherVeryLongName") !== -1;
+				var hasDevCode = actualJS.indexOf("remove this") !== -1;
+				var hasEnvifyCode = actualJS.indexOf("when envify is turned on this should be removed") !== -1;
+
+				assert(!hasEnvifyCode, "Minified source has kept envify test code.");
 				assert(!hasDevCode, "Minified source has dev code removed.");
 				assert(!hasLongVariable, "Minified source renamed long variable.");
 				assert(!hasGlobalLongVariable, "Minified source includes a global that was minified.");


### PR DESCRIPTION
This is the result of discussion in https://github.com/stealjs/steal-tools/issues/630 (specifically this comment https://github.com/stealjs/steal-tools/issues/630#issuecomment-286754274)

loose-envify (derived from the envify plugin for browserify) replaces Node-style environment variables with plain strings. 

For example, given that the environment variable NODE_ENV='dev' the following code
```javascript
if(process.env.NODE_ENV === 'prod') { /* run production-only code */ }
```

will be transformed to
```javascript
if('dev' === 'prod') { /* run production-only code */ }
```

This will then allow uglify-js dead code removal algorithm to remove this if statement since 'dev' === 'prod' will always be false. If NODE_ENV was set to 'prod' then the code would not be removed.

In this pull-request I've also added a new option "envify" which defaults to false and controls whether envify will or will not be called during minification.