### PR TITLE
steal-tools build writes out UTF-8 correctly

### DIFF
--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -2467,4 +2467,29 @@ describe("multi build", function(){
 				assert.ok(true, "it works!");
 			});
 	});
+
+	it("writes out UTF-8 correctly", function(done) {
+		var base = path.join(__dirname, "utf8");
+
+		asap(rmdir)(path.join(base, "dist"))
+			.then(function() {
+				return multiBuild({
+					main: "utf8/main",
+					config: path.join(__dirname, "stealconfig.js")
+				}, {
+					quiet: true,
+					dest: path.join(base, "dist")
+				});
+			})
+			.then(function() {
+				var page = path.join("test", "utf8", "prod.html");
+
+				open(page, function(browser, close) {
+					find(browser, "foo", function(foo) {
+						assert.equal(foo, "捕");
+						done();
+					}, close);
+				}, done);
+			});
+	});
 });

--- a/test/utf8/main.js
+++ b/test/utf8/main.js
@@ -1,0 +1,2 @@
+window.foo = "捕";
+document.getElementById("message").innerHTML = window.foo;

--- a/test/utf8/prod.html
+++ b/test/utf8/prod.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>UTF-8 to Unicode</title>
+</head>
+<body>
+	<div id="message"></div>
+	<script src="./dist/steal.production.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Closes #310 

The test passes and it looks right to me on the browser 

![google chrome](https://cloud.githubusercontent.com/assets/724877/25100444/4ee8c336-236d-11e7-8df3-2529e5913d6b.png)
