### PR TITLE
Improve steal-tools.export docs

### DIFF
--- a/doc/export.md
+++ b/doc/export.md
@@ -10,8 +10,8 @@ Export a project's modules to other forms and formats declaratively.
   @option {steal-tools.StealConfig} Steal `config` data needed to load
   all the modules for export.
 
-  @option {{}} [options] Options that configure logging.
-  
+  @option {steal-tools.export.object} Options that configure logging.
+
   @option {Object<String,steal-tools.export.output>} outputs Configures output files to be written.
 
 @param {Object<String,steal-tools.export.output>} [defaults] An object of names and default ExportOutput

--- a/doc/types/build-options.md
+++ b/doc/types/build-options.md
@@ -38,7 +38,7 @@ process; the second parameter, `options`, is the [steal-tools.BuildOptions] obje
 
 @option {Boolean} [bundleSteal=false] Sets whether StealJS will be included in the built file. Enabling this option will allow you to limit the initial request to just one script.
 
-@option {Boolean} [debug=false] `true` turns on debug messages. Defaults to `false`.
+@option {Boolean} [verbose=false] `true` turns on verbose output. Defaults to `false`.
 
 @option {Boolean} [quiet=false] No logging.  Defaults to `false`.
 

--- a/doc/types/export-object.md
+++ b/doc/types/export-object.md
@@ -1,5 +1,6 @@
 @typedef {{}} steal-tools.export.object ExportObject
 @parent steal-tools.types
+@templateRender true
 
 An object that specifies the modules to load and their outputs. This is used by
 [steal-tools.export] and [steal-tools.grunt.export].
@@ -17,9 +18,8 @@ steal: {
 
 @option {{}} options Options that configure the following:
 
-  @option {Boolean} [debug=false] `true` turns on debug messages. Defaults to `false`.
-  
-  @option {Boolean} [quiet=false] No logging.  Defaults to `false`.
+ - [debug=false] `true` turns on debug messages. Defaults to `false`.
+ - [quiet=false] No logging.  Defaults to `false`.
 
 
 @option {Object<String,steal-tools.export.output>} outputs Configures output files to be written.


### PR DESCRIPTION
- Add a link to the ExportObject in export.md
- Turn on templateRender to process handlebars helpers
- Make sure the ExportObject `options` are rendered correctly

Closes #436 

![screen shot 2017-04-19 at 08 37 10](https://cloud.githubusercontent.com/assets/724877/25186044/36cddf6e-24dc-11e7-874c-ee6c4d137037.png)
![screen shot 2017-04-19 at 08 37 26](https://cloud.githubusercontent.com/assets/724877/25186045/37050b4c-24dc-11e7-96e3-768091bc01e3.png)