### PR TITLE
Disable clean-css import inlining 

### DIFF
--- a/lib/assign_default_options.js
+++ b/lib/assign_default_options.js
@@ -11,7 +11,9 @@ module.exports = function(config, options){
 		minify: false,
 		bundleSteal: false,
 		uglifyOptions: {},
-		cleanCSSOptions: {},
+		cleanCSSOptions: {
+			inline: ["none"]
+		},
 		removeDevelopmentCode: true,
 		namedDefines: true,
 		maxBundleRequests: options.maxBundleRequests || options.bundleDepth,

--- a/lib/build/multi.js
+++ b/lib/build/multi.js
@@ -100,10 +100,10 @@ module.exports = function(config, options){
 
 		// Return a Promise that will resolve after bundles have been written;
 		return new Promise(function(resolve, reject){
+			var bundleWriteStream = concatStream.pipe(createWriteStream());
+
 			// Pipe the build result into a write stream.
-			var writeStream = concatStream
-				.pipe(createWriteStream())
-				.pipe(stealWriteStream());
+			var writeStream = bundleWriteStream.pipe(stealWriteStream());
 
 			writeStream.on("data", function(data){
 				this.end();
@@ -126,6 +126,7 @@ module.exports = function(config, options){
 			  transpileStream,
 			  minifyStream,
 			  buildStream,
+		      bundleWriteStream,
 			  writeStream
 			].forEach(function(stream){
 				stream.on("error", reject);

--- a/lib/buildTypes/minifyCSS.js
+++ b/lib/buildTypes/minifyCSS.js
@@ -1,19 +1,21 @@
-var CleanCSS = require('clean-css');
+var CleanCSS = require("clean-css");
+var assign = require("lodash/assign");
 
-module.exports = function(source, options){
-	var opts = (options != null) ? options.cleanCSSOptions : {};
-	opts = opts || {};
-	
+module.exports = function(source, options) {
+	var opts = assign({}, options && options.cleanCSSOptions, {
+		returnPromise: true
+	});
+
 	if(options.sourceMaps) {
 		opts.sourceMap = source.map ? source.map+"" : true;
 	}
 
-	var code = source.code;
-
-	var result = new CleanCSS(opts).minify(code);
-
-	return {
-		code: result.styles,
-		map: result.sourceMap
-	};
+	return new CleanCSS(opts)
+		.minify(source.code)
+		.then(function(result) {
+			return {
+				code: result.styles,
+				map: result.sourceMap
+			};
+		});
 };

--- a/lib/bundle/minify_source.js
+++ b/lib/bundle/minify_source.js
@@ -4,8 +4,8 @@ module.exports = function(bundle, options) {
 	options = options || {};
 
 	if (options.minify && bundle.buildType === "css") {
-		bundle.source = minifyCSS(bundle.source, options);
+		return minifyCSS(bundle.source, options);
 	}
 
-	return bundle;
+	return Promise.resolve(bundle.source);
 };

--- a/lib/bundle/write_bundles.js
+++ b/lib/bundle/write_bundles.js
@@ -1,82 +1,72 @@
 // # lib/bundle/write_bundles.js
 // Given an array of bundles and the baseURL
 // Writes them out to the file system.
-var bundleFilename = require("./filename"),
-	fs = require("fs"),
-	mkdirp = require("fs-extra").mkdirp,
-	dirname = require("path").dirname,
-	addSourceMapUrl = require("../bundle/add_source_map_url"),
-	through = require("through2"),
-	winston = require("winston"),
-	minifySource = require("./minify_source");
+var bundleFilename = require("./filename");
+var dirname = require("path").dirname;
+var addSourceMapUrl = require("../bundle/add_source_map_url");
+var through = require("through2");
+var winston = require("winston");
+var minifySource = require("./minify_source");
+
+var denodeify = require("pdenodeify");
+var writeFile = denodeify(require("fs").writeFile);
+var mkdirp = denodeify(require("fs-extra").mkdirp);
 
 var writeBundles = module.exports = function(bundles, configuration) {
 	// Create the bundle directory
 	var bundleDirDef = configuration.mkBundlesPathDir();
 
-	// A deferred containing a deferred that resolves when all
-	// deferreds have been built.
-	var builtBundleDeferreds = [];
+	var processBundle = function(bundle) {
+		var bundlePath = bundle.bundlePath;
 
-	bundles.forEach(function(bundle) {
-		builtBundleDeferreds.push(new Promise(function(resolve, reject) {
-			var bundlePath = bundle.bundlePath;
+		// If the bundle is explicity marked as clean, just resolve.
+		if (bundle.isDirty === false) {
+			return Promise.resolve(bundle);
+		}
 
-			// If the bundle is explicity marked as clean, just resolve.
-			if(bundle.isDirty === false) {
-				return resolve(bundle);
-			}
+		var sourceCode;
+		var sourceMap;
 
-			// minify concatenated source
-			minifySource(bundle, configuration.options);
+		// minify concatenated source
+		return minifySource(bundle, configuration.options)
+			.then(function(minified) {
+				bundle.source = minified;
 
-			var code = bundle.source.code, map;
-			if(configuration.options.sourceMaps) {
-				addSourceMapUrl(bundle);
-				code = bundle.source.code;
-				map = bundle.source.map;
-			}
+				sourceCode = bundle.source.code;
+				if (configuration.options.sourceMaps) {
+					addSourceMapUrl(bundle);
+					sourceCode = bundle.source.code;
+					sourceMap = bundle.source.map;
+				}
 
-			// Log the bundles
-			winston.info("BUNDLE: %s", bundleFilename(bundle));
-			winston.debug(Buffer.byteLength(code, "utf8") + " bytes");
+				// Log the bundles
+				winston.info("BUNDLE: %s", bundleFilename(bundle));
+				winston.debug(Buffer.byteLength(sourceCode, "utf8") + " bytes");
 
-			bundle.nodes.forEach(function(node) {
-				winston.info("+ %s", node.load.name);
-			});
-
-			// Once a folder has been created, write out the bundle source
-			bundleDirDef.then(function() {
-				mkdirp(dirname(bundlePath), function(err) {
-					if (err) {
-						reject(err);
-					}
-					else {
-						fs.writeFile(bundlePath, code, function(err) {
-							if(err) {
-								reject(err);
-							} else {
-								if(!map) {
-									resolve(bundle);
-									return;
-								}
-								// Write out the source map
-								fs.writeFile(bundlePath+".map", map, function(err) {
-									if(err) return reject(err);
-									resolve(bundle);
-								});
-							}
-						});
-					}
+				bundle.nodes.forEach(function(node) {
+					winston.info("+ %s", node.load.name);
 				});
 
-			}).catch(function(err) {
-				reject(err);
+				return bundleDirDef;
+			})
+			// Once a folder has been created, write out the bundle source
+			.then(function() {
+				return mkdirp(dirname(bundlePath));
+			})
+			.then(function() {
+				return writeFile(bundlePath, sourceCode);
+			})
+			.then(function() {
+				if (sourceMap) {
+					return writeFile(bundlePath+".map", sourceMap);
+				}
+			})
+			.then(function() {
+				return bundle;
 			});
-		}));
-	});
+	};
 
-	return Promise.all(builtBundleDeferreds);
+	return Promise.all(bundles.map(processBundle));
 };
 
 writeBundles.createWriteStream = function(){
@@ -84,9 +74,11 @@ writeBundles.createWriteStream = function(){
 		var configuration = buildResult.configuration;
 		var bundles = buildResult.bundles;
 
-		writeBundles(bundles, configuration).then(function(){
-			done(null, buildResult);
-		}, done);
+		writeBundles(bundles, configuration)
+			.then(function() {
+				done(null, buildResult);
+			})
+			.catch(done);
 	}
 
 	return through.obj(write);

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "rimraf": "^2.5.2",
     "serve-static": "^1.11.2",
     "steal-conditional": "^0.3.2",
-    "steal-css": "^1.2.3",
     "steal-qunit": "^1.0.0",
     "testee": "^0.4.0",
     "tree-kill": "^1.0.0"
@@ -137,8 +136,7 @@
   },
   "system": {
     "npmDependencies": [
-      "steal-qunit",
-      "steal-css"
+      "steal-qunit"
     ]
   },
   "greenkeeper": {

--- a/test/broken_css_build/main.css
+++ b/test/broken_css_build/main.css
@@ -1,0 +1,1 @@
+@import "missing.css";

--- a/test/broken_css_build/main.js
+++ b/test/broken_css_build/main.js
@@ -1,0 +1,1 @@
+require("./main.css!");

--- a/test/broken_css_build/stealconfig.js
+++ b/test/broken_css_build/stealconfig.js
@@ -1,0 +1,8 @@
+steal.config({
+	ext: {
+		"css": "steal-css"
+	},
+	paths: {
+		"steal-css": "../steal-css.js"
+	}
+});

--- a/test/css_imports/foo.css
+++ b/test/css_imports/foo.css
@@ -1,0 +1,3 @@
+body {
+	background-color: yellow;
+}

--- a/test/css_imports/main.css
+++ b/test/css_imports/main.css
@@ -1,0 +1,1 @@
+@import "foo.css";

--- a/test/css_imports/main.js
+++ b/test/css_imports/main.js
@@ -1,0 +1,1 @@
+require("./main.css!");

--- a/test/css_imports/stealconfig.js
+++ b/test/css_imports/stealconfig.js
@@ -1,0 +1,8 @@
+steal.config({
+	ext: {
+		"css": "steal-css"
+	},
+	paths: {
+		"steal-css": "../steal-css.js"
+	}
+});

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -2072,4 +2072,29 @@ describe("multi build", function(){
 				});
 			});
 	});
+
+	it("does not swallow clean-css errors", function(done) {
+		var base = path.join(__dirname, "broken_css_build");
+
+		asap(rmdir)(path.join(base, "dist"))
+			.then(function() {
+				return multiBuild({
+					main: "main",
+					config: path.join(base, "stealconfig.js")
+				}, {
+					quiet: true,
+					cleanCSSOptions: {
+						inline: ["all"] // set inline @import to trigger build error
+					}
+				});
+			})
+			.then(function() {
+				assert.ok(false, "build promise should not resolve");
+				done();
+			})
+			.catch(function(err) {
+				assert.ok(!!err, "build promise should be rejected");
+				done();
+			});
+	});
 });

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -2097,4 +2097,24 @@ describe("multi build", function(){
 				done();
 			});
 	});
+
+	it("css imports are not inlined by default", function() {
+		var base = path.join(__dirname, "css_imports");
+
+		return asap(rmdir)(path.join(base, "dist"))
+			.then(function() {
+				return multiBuild({
+					main: "main",
+					config: path.join(base, "stealconfig.js")
+				}, {
+					quiet: true
+				});
+			})
+			.then(function() {
+				var source = fs.readFileSync(path.join(base, "dist", "bundles",
+					"main.css"));
+
+				assert.ok(/\@import/.test(source), "@imports are not inlined");
+			});
+	});
 });

--- a/test/steal-css.js
+++ b/test/steal-css.js
@@ -1,0 +1,35 @@
+var steal = require("@steal");
+var loader = require("@loader");
+
+function CSSModule(address, source) {
+	this.address = address;
+	this.source = source;
+}
+
+CSSModule.prototype.injectStyle = function() {
+	var head = document.head;
+	var style = document.createElement("style");
+
+	style.type = "text/css";
+	style.styleSheet.cssText = this.source;
+
+	head.appendChild(style);
+};
+
+exports.instantiate = function(load) {
+	var loader = this;
+	var css = new CSSModule(load.address, load.source);
+
+	load.metadata.deps = [];
+	load.metadata.format = "css";
+	load.metadata.execute = function() {
+		css.injectStyle();
+
+		return loader.newModule({
+			source: css.source
+		});
+	};
+};
+
+exports.buildType = "css";
+exports.includeInBuild = true;


### PR DESCRIPTION
- Disable clean-css import inlining
- Remove unused steal-css dependency
- Use clean-css promise based interface
- Refactor write_source to use a promise chain (such wow, much edit, very chainy)
- Split `writeStream` to handle errors coming from bundle's write_source stream  
- Add test to make sure steal-tools does not swallow clean-css errors

Closes #487