### PR TITLE
Better build error message when "main" is missing

### DIFF
--- a/lib/graph/make_graph.js
+++ b/lib/graph/make_graph.js
@@ -118,6 +118,17 @@ module.exports = function(config, options){
 
 		return appPromise.then(function(){
 			var main = localSteal.System.main;
+
+			if (_.isUndefined(main)) {
+				return Promise.reject(
+					new Error(
+						"Attribute 'main' is required\n" +
+						"Add 'main' to the StealConfig object or to your StealJS configuration file.\n" +
+						"See http://stealjs.com/docs/steal-tools.StealConfig.html for more details."
+					)
+				);
+			}
+
 			var mains = Array.isArray(main) ? main : [main];
 			var normalizedPromises = mains.map(function(main){
 				return Promise.resolve(localSteal.System.normalize(main));

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -2117,4 +2117,26 @@ describe("multi build", function(){
 				assert.ok(/\@import/.test(source), "@imports are not inlined");
 			});
 	});
+
+	it("error message when main is missing", function(done) {
+		var base = path.join(__dirname, "bundle");
+
+		var buildPromise = multiBuild({
+			config: path.join(base, "stealconfig.js")
+		}, {
+			quiet: true,
+			minify: false
+		});
+
+		buildPromise
+			.then(function() {
+				assert.ok(false, "'main' is missing");
+				done();
+			})
+			.catch(function(err) {
+				assert(/Attribute 'main' is required/.test(err.message),
+					"should fail with a nice error message");
+				done();
+			});
+	});
 });


### PR DESCRIPTION
I did some research into the state of the art of error messaging in node but did not find any pre-cooked library to help here.

I ended up with a error message with the following format

> Error: short title
> Something actionable for the user 
>A help url, hopefully to the StealJS docs

The missing main looks like:

> Error: Attribute 'main' is required
> Add 'main' to the StealConfig object or to your StealJS configuration file.
> See http://stealjs.com/docs/steal-tools.StealConfig.html for more details.
>     at /Users/mmujica/Projects/steal-tools/lib/graph/make_graph.js:124:6
>     at tryCatchReject (/Users/mmujica/Projects/steal-tools/node_modules/steal/src/loader/loader.js:1183:30)
>     at runContinuation1 (/Users/mmujica/Projects/steal-tools/node_modules/steal/src/loader/loader.js:1142:4)
>     at Fulfilled.when (/Users/mmujica/Projects/steal-tools/node_modules/steal/src/loader/loader.js:930:4)
>     at Pending.run (/Users/mmujica/Projects/steal-tools/node_modules/steal/src/loader/loader.js:821:13)
>     at Scheduler._drain (/Users/mmujica/Projects/steal-tools/node_modules/steal/src/loader/loader.js:97:19)
>     at Scheduler.drain (/Users/mmujica/Projects/steal-tools/node_modules/steal/src/loader/loader.js:62:9)
>     at _combinedTickCallback (internal/process/next_tick.js:67:7)
>     at process._tickCallback (internal/process/next_tick.js:98:9)


Closes #677 

