### PR TITLE
Better export error message when `dest` is missing

### DIFF
--- a/lib/build/export.js
+++ b/lib/build/export.js
@@ -117,19 +117,28 @@ module.exports = function(config, defaults, modules){
 		var result = transform(moduleNames, options);
 		var filePath;
 
-		if(_.isString(out.output.dest)) {
+		if (_.isUndefined(out.output.dest)) {
+			return Promise.reject(new Error(
+				"Attribute 'dest' is required\n" +
+				"Add 'dest' to the ExportOutput object.\n" +
+				"See http://stealjs.com/docs/steal-tools.export.output.html#dest for more details."
+			));
+		}
+		else if (_.isString(out.output.dest)) {
 			filePath = out.output.dest;
-		} else {
-			// pull out the moduleNames
-			var loads = (_.isString(moduleNames) ?
-				transform.graph[moduleNames].load :
-				moduleNames.map(function(moduleName){
-					return transform.graph[moduleName].load;
-				}));
+		}
+		else if (_.isFunction(out.output.dest)) {
+			// pull out the load objects of the modules being written out
+            var loads = (_.isString(moduleNames) ?
+                transform.graph[moduleNames].load :
+                moduleNames.map(function(moduleName){
+                    return transform.graph[moduleName].load;
+                }));
 
 			filePath = out.output.dest(moduleNames,
 				modulesMap[moduleNames], loads, transform.loader);
 		}
+
 		winston.info("> " + filePath);
 		return writeFile(filePath, result, config);
 	};

--- a/test/export_test.js
+++ b/test/export_test.js
@@ -247,6 +247,34 @@ describe("export", function(){
 			});
 	});
 
+	it("errors out when 'dest' is not provided", function(done) {
+		var exportPromise = stealExport({
+			steal: {
+				config: path.join(__dirname, "circular", "package.json!npm")
+			},
+			options: {
+				quiet: true
+			},
+			outputs: {
+				amd: {
+					minify: false,
+					format: "amd",
+					modules: ["circular/main"]
+				}
+			}
+		});
+
+		exportPromise
+			.then(function() {
+				assert(false, "should fail, 'dest' is missing");
+			})
+			.then(done, function(err) {
+				assert(/Attribute 'dest' is required/.test(err.message),
+					"should fail with a nice error");
+				done();
+			});
+	});
+
 	describe("eachModule", function(){
 		it("works", function(done){
 			stealExport({


### PR DESCRIPTION
I tried to make export to write out to a default path if `dest` was missing to avoid throwing altogether; I tried using the `moduleNames` to generate the path but it's a pain, the names can be normalized or have `/` in it, etc.

Ended up adding the error, in the docs `dest` is not option so I guess that's ok. 

Closes #676 
