### PR TITLE
Fix regressions in Node 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - 4
   - 6.0
   - node
 before_script:

--- a/lib/graph/make_graph_with_bundles.js
+++ b/lib/graph/make_graph_with_bundles.js
@@ -52,7 +52,7 @@ function mergeIntoMasterAndAddBundle(opts) {
 
 		// do not track bundles of entry point modules (a.k.a mains) unless
 		// it is its own bundle.
-		if (name === bundleName || !mains.includes(name)) {
+		if (name === bundleName || !_.includes(mains, name)) {
 			addBundle(masterGraph[name], bundleName);
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
       },
       "4.x.x": {
         "devDependencies": {
-          "zombie": "^3.1.1"
+          "zombie": "^4.2.1"
         }
       },
       "^5.0.0": {


### PR DESCRIPTION
- Do not use Array::includes
- Use zombie@4 because of https://github.com/stealjs/steal/pull/1181
- Run tests in Node 4 (Travis)