### PR TITLE
Use pump library in steal-tools build code

### DIFF
--- a/lib/build/multi.js
+++ b/lib/build/multi.js
@@ -58,6 +58,7 @@ It manipulates this graph and eventually creates "bundle" graphs.  Bundle graphs
 The nodes in those bundles are written to the filesystem.
 
 */
+var pump = require("pump");
 var assignDefaultOptions = require("../assign_default_options");
 var bundle = require("../stream/bundle");
 var createBundleGraphStream = require("../graph/make_graph_with_bundles").createBundleGraphStream;
@@ -88,22 +89,21 @@ module.exports = function(config, options){
 			return Promise.reject(err);
 		}
 
-		// Get a stream containing the bundle graph
-		var graphStream = createBundleGraphStream(config, options);
-		// Pipe the bundle graph into the multiBuild steps
-		var transpileStream = graphStream.pipe(transpile());
-		var minifyStream = transpileStream.pipe(minify());
-		var buildStream = minifyStream.pipe(bundle());
-		//var buildStream = graphStream.pipe(multiBuild());
-		// Pipe the buildStream into concatenation
-		var concatStream = buildStream.pipe(concat());
-
 		// Return a Promise that will resolve after bundles have been written;
-		return new Promise(function(resolve, reject){
-			var bundleWriteStream = concatStream.pipe(createWriteStream());
-
-			// Pipe the build result into a write stream.
-			var writeStream = bundleWriteStream.pipe(stealWriteStream());
+		return new Promise(function(resolve, reject) {
+			var writeStream = pump(
+				createBundleGraphStream(config, options),
+				transpile(),
+				minify(),
+				bundle(),
+				concat(),
+				createWriteStream(),
+				stealWriteStream(),
+				function(err) {
+					// reject the promise if any of the streams fail
+					if (err) reject(err);
+				}
+			);
 
 			writeStream.on("data", function(data){
 				this.end();
@@ -121,17 +121,6 @@ module.exports = function(config, options){
 
 				resolve(data);
 			});
-
-			[ graphStream,
-			  transpileStream,
-			  minifyStream,
-			  buildStream,
-		      bundleWriteStream,
-			  writeStream
-			].forEach(function(stream){
-				stream.on("error", reject);
-			});
 		});
 	}
-
 };

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "mocha-lcov-reporter": "^1.2.0",
     "mock-fs": "4.2.0",
     "mockery": "^2.0.0",
+    "pump": "^1.0.2",
     "rimraf": "^2.5.2",
     "serve-static": "^1.11.2",
     "steal-conditional": "^0.3.4",


### PR DESCRIPTION
With pump we can remove all the intermediate streams for the error handling.

needed a small win 🏆 