### PR TITLE
Set greenkeeper to ignore uglify-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
   },
   "greenkeeper": {
     "ignore": [
-      "traceur"
+      "traceur",
+      "uglify-js"
     ]
   }
 }


### PR DESCRIPTION
steal@2 will probably drop uglify-js and use a es6 friendly minifier; uglify-js@3 has a breaking api and we are not planning to get it to work, yet...