### PR TITLE
Adds buildResult as resolved value for stealTools.export

### DIFF
--- a/doc/export.md
+++ b/doc/export.md
@@ -1,5 +1,5 @@
 @function steal-tools.export export
-@parent steal-tools.JS 
+@parent steal-tools.JS
 
 Export a project's modules to other forms and formats declaratively.  
 
@@ -20,7 +20,7 @@ values.
 @param {Array<{}>} [modules] An array of module data that an [steal-tools.export.output]'s
 `modules`, `eachModule`, `graphs`, or `ignore` can be filtered against.
 
-@return {Promise} A promise that resolves when all outputs have been written out.
+@return {(Promise<steal-tools.BuildResult>)} A Promise that resolves when all outputs have been written out.
 
 @body
 
@@ -67,7 +67,7 @@ The first argument is an [steal-tools.export.object].  Details about its API and
 
 ## defaults
 
-As there are times when the same options may need to be set over and over again, the `defaults` option can 
+As there are times when the same options may need to be set over and over again, the `defaults` option can
 contain default values each output can call:
 
 ```

--- a/lib/build/export.js
+++ b/lib/build/export.js
@@ -236,8 +236,12 @@ module.exports = function(config, defaults, modules){
 
 	return transformImport(config.steal, config.options)
 		.then(function(configPluginify){
+			var buildResult = configPluginify.data;
 			return Promise.all(config.outputs.map(function(out) {
 				return processOutput(configPluginify, out);
-			}));
+			}))
+			.then(function(){
+				return buildResult;
+			});
 		});
 };

--- a/lib/build/transform.js
+++ b/lib/build/transform.js
@@ -35,7 +35,7 @@ var transformImport = function(config, transformOptions){
 	logging.setup(transformOptions, config);
 
 	return makeGraph(config, transformOptions).then(function(data){
-		
+
 		return transformImport.normalizeExports(data.steal.System,
 												transformOptions)
 		.then(function(){
@@ -54,7 +54,8 @@ var transformImport = function(config, transformOptions){
 				ignoreAllDependencies: false,
 				removeSourceNodes: true
 			},transformOptions, options);
-			var configuration = makeConfiguration(data.loader, data.buildLoader, options);
+			var configuration = data.configuration =
+				makeConfiguration(data.loader, data.buildLoader, options);
 
 			if(!moduleNames) {
 				moduleNames = data.loader.main;
@@ -148,6 +149,7 @@ var transformImport = function(config, transformOptions){
 		// Set the graph on transform in case anyone needs to use it.
 		transform.graph = data.graph;
 		transform.loader = data.loader;
+		transform.data = data;
 		return transform;
 
 

--- a/test/export_test.js
+++ b/test/export_test.js
@@ -11,7 +11,6 @@ var open = testHelpers.open;
 
 describe("export", function(){
 	it("basics work", function(done){
-
 		stealExport({
 
 			steal: {
@@ -38,7 +37,13 @@ describe("export", function(){
 					minify: false
 				}
 			}
-		}).then(function(){
+		}).then(function(data){
+			// Includes all buildResult fields
+			assert(!!data.configuration, "configuration");
+			assert(!!data.graph, "graph");
+			assert(!!data.loader, "loader");
+			assert(!!data.steal, "steal");
+
 			open("test/pluginifier_builder/index.html", function(browser, close){
 
 				find(browser,"RESULT", function(result){
@@ -55,7 +60,6 @@ describe("export", function(){
 
 	it("works with multiple mains", function(done){
 		stealExport({
-
 			steal: {
 				main: [
 					"pluginifier_builder/pluginify",


### PR DESCRIPTION
Closes #266

Adds the steal-tools.buildResult object as being the exported value from
stealTools.export, the same way as with stealTools.build. This means
using export you get the following information:

- **configuration**: An object with details of where files are to be written
out to.
- **graph**: The dependency graph for the export.
- **loader**: The steal.loader that was used to trace the dependencies.
- **steal**: The steal object that was used to trace the dependencies.