### PR TITLE
Watch mode should not minify by default

### DIFF
--- a/lib/cli/cmd_build.js
+++ b/lib/cli/cmd_build.js
@@ -1,8 +1,15 @@
 var winston = require("winston");
 var stealTools = require("../../index");
+var makeStealConfig = require("./make_steal_config");
+var makeBuildOptions = require("./make_build_options");
+
 var clone = require("lodash/cloneDeep");
 var options = clone(require("./options"));
-var makeStealConfig = require("./make_steal_config");
+
+// turns off default minification because its value is conditional
+// keeping it `true` by default makes it impossible to tell whether
+// the user explicitly passed `--watch`
+options.minify.default = false;
 
 module.exports = {
 	command: ["build", "*"], // `*` makes this the default command
@@ -12,10 +19,10 @@ module.exports = {
 	builder: options,
 
 	handler: function(argv) {
-		var options = argv;
-		var config = makeStealConfig(argv);
-
-		var promise = stealTools.build(config, options);
+		var promise = stealTools.build(
+			makeStealConfig(argv),
+			makeBuildOptions(argv)
+		);
 
 		// If this is watch mode this is actually a stream.
 		if (promise.then) {

--- a/lib/cli/make_build_options.js
+++ b/lib/cli/make_build_options.js
@@ -1,0 +1,31 @@
+var clone = require("lodash/clone");
+var omitBy = require("lodash/omitBy");
+var compact = require("lodash/compact");
+var includes = require("lodash/includes");
+var commandOptions = require("./options");
+
+/**
+ * Convert the arv into a BuildOptions object
+ * @param {Object} argv Command arguments provided by yargs
+ * @return {BuildOptions} The build options object
+ */
+module.exports = function(argv) {
+	var options = clone(argv);
+
+	if (options.noMinify) {
+		options.minify = false;
+	}
+
+	// if no explicit value was set, default it to true unless watch mode is used
+	if (options.minify == null) {
+		options.minify = options.watch ? false : true;
+	}
+
+	var aliases = compact(Object.keys(commandOptions).map(function(o) {
+		return commandOptions[o].alias;
+	}));
+
+	return omitBy(options, function(value, key) {
+		return includes(aliases, key) || includes(key, "-");
+	});
+};

--- a/test/cli/cmd_build_test.js
+++ b/test/cli/cmd_build_test.js
@@ -65,4 +65,18 @@ describe("cmd build module", function() {
 			bundlesPath: "foo"
 		});
 	});
+
+	it("watch mode defaults minify to false", function() {
+		cmdBuild.handler({ config: "/stealconfig.js", watch: true });
+		assert.equal(buildArgs.options.minify, false);
+	});
+
+	it("watch mode should still minify if flag provided", function() {
+		cmdBuild.handler({
+			config: "/stealconfig.js",
+			watch: true,
+			minify: true
+		});
+		assert.equal(buildArgs.options.minify, true);
+	});
 });

--- a/test/cli/make_build_options_test.js
+++ b/test/cli/make_build_options_test.js
@@ -1,0 +1,44 @@
+var assert = require("assert");
+var makeBuildOptions = require("../../lib/cli/make_build_options");
+
+describe("makeBuildConfig", function() {
+	it("removes aliases", function() {
+		var options = makeBuildOptions({ m: "main", main: "main" });
+		assert(options.m == null);
+		assert.equal(options.main, "main");
+	});
+
+	it("removes keys with - in it", function() {
+		var options = makeBuildOptions({ "bundle-steal": false, bundleSteal: false });
+		assert(options["bundle-steal"] == null);
+		assert.equal(options.bundleSteal, false);
+	});
+
+	it("sets 'minify' value appropiately", function() {
+		assert.equal(makeBuildOptions({}).minify, true, "defaults to true");
+
+		assert.equal(
+			makeBuildOptions({ minify: false }).minify,
+			false,
+			"should not be mutated if set explicitly to false"
+		);
+
+		assert.equal(
+			makeBuildOptions({ watch: true }).minify,
+			false,
+			"should default to false for watch mode"
+		);
+
+		assert.equal(
+			makeBuildOptions({ watch: true, minify: true }).minify,
+			true,
+			"should not be mutated if set to true"
+		);
+
+		assert.equal(
+			makeBuildOptions({ noMinify: true }).minify,
+			false,
+			"cannot be true if 'no-minify' is true"
+		);
+	});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -17,6 +17,7 @@ require("./cli/cmd_export_test");
 require("./cli/make_outputs_test");
 require("./cli/cmd_live_test");
 require("./get_es_module_imports_test");
+require("./cli/make_build_options_test");
 
 // Integration tests
 require("./test_cli");


### PR DESCRIPTION
Closes #708 

This one turned out to be a bit tricky, because you still want to minify if the flag was passed as in:

```
steal-tools build --watch --minify
```

but since we were using yargs default value, we could not tell whether minify was set by the user at the point were we were looking at `watch` value.

The solution was to stop using the default minify value only in the build command and pass options through a function that takes care of setting its value. 