### PR TITLE
Watch mode should have quiet output by default

### DIFF
--- a/lib/cli/cmd_build.js
+++ b/lib/cli/cmd_build.js
@@ -1,15 +1,19 @@
 var winston = require("winston");
+var assign = require("lodash/assign");
+var clone = require("lodash/cloneDeep");
 var stealTools = require("../../index");
 var makeStealConfig = require("./make_steal_config");
 var makeBuildOptions = require("./make_build_options");
 
-var clone = require("lodash/cloneDeep");
-var options = clone(require("./options"));
-
-// turns off default minification because its value is conditional
-// keeping it `true` by default makes it impossible to tell whether
-// the user explicitly passed `--watch`
-options.minify.default = false;
+/**
+ * Disable default values for conditional properties:
+ *	Default values make it impossible for the `handler` callback
+ *  to tell whether the user explicitly set a value or not
+ */
+var options = assign(clone(require("./options")), {
+	minify: undefined,
+	quiet: undefined
+});
 
 module.exports = {
 	command: ["build", "*"], // `*` makes this the default command

--- a/lib/cli/make_build_options.js
+++ b/lib/cli/make_build_options.js
@@ -2,6 +2,7 @@ var clone = require("lodash/clone");
 var omitBy = require("lodash/omitBy");
 var compact = require("lodash/compact");
 var includes = require("lodash/includes");
+var defaults = require("lodash/defaults");
 var commandOptions = require("./options");
 
 /**
@@ -16,10 +17,14 @@ module.exports = function(argv) {
 		options.minify = false;
 	}
 
-	// if no explicit value was set, default it to true unless watch mode is used
-	if (options.minify == null) {
-		options.minify = options.watch ? false : true;
+	if (options.verbose) {
+		options.quiet = false;
 	}
+
+	defaults(options, {
+		minify: options.watch ? false : true,
+		quiet: options.watch ? true : false
+	});
 
 	var aliases = compact(Object.keys(commandOptions).map(function(o) {
 		return commandOptions[o].alias;

--- a/test/cli/make_build_options_test.js
+++ b/test/cli/make_build_options_test.js
@@ -41,4 +41,26 @@ describe("makeBuildConfig", function() {
 			"cannot be true if 'no-minify' is true"
 		);
 	});
+
+	it("sets 'quiet' value appropiately", function() {
+		assert.equal(makeBuildOptions({}).quiet, false, "defaults to false");
+
+		assert.equal(
+			makeBuildOptions({ watch: true }).quiet,
+			true,
+			"should default to true for watch mode"
+		);
+
+		assert.equal(
+			makeBuildOptions({ watch: true, quiet: false }).quiet,
+			false,
+			"should not be mutated if set"
+		);
+
+		assert.equal(
+			makeBuildOptions({ watch: true, verbose: true }).quiet,
+			false,
+			"cannot be true if verbose output is set"
+		);
+	});
 });


### PR DESCRIPTION
Closes #707

negated-dependant properties like no-minify/minify or verbose/quiet make me want to use computes to keep them in sync :D 