### PR TITLE
Test conditionals using browser specific code

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mockery": "^2.0.0",
     "rimraf": "^2.5.2",
     "serve-static": "^1.11.2",
-    "steal-conditional": "stealjs/steal-conditional#eval-cond",
+    "steal-conditional": "^0.3.5",
     "steal-qunit": "^1.0.0",
     "testee": "^0.4.0",
     "tree-kill": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mockery": "^2.0.0",
     "rimraf": "^2.5.2",
     "serve-static": "^1.11.2",
-    "steal-conditional": "^0.3.4",
+    "steal-conditional": "stealjs/steal-conditional#eval-cond",
     "steal-qunit": "^1.0.0",
     "testee": "^0.4.0",
     "tree-kill": "^1.0.0",

--- a/test/build_conditionals_test.js
+++ b/test/build_conditionals_test.js
@@ -172,6 +172,26 @@ describe("build app using steal-conditional", function() {
 			});
 	});
 
+	it("condition module should not be evaluated during build", function() {
+		this.timeout(20000);
+
+		var bundles = path.join(basePath, "condition-module", "dist", "bundles");
+
+		var config = {
+			config: path.join(basePath, "condition-module", "package.json!npm")
+		};
+
+		return prmdir(path.join(basePath, "boolean", "dist"))
+			.then(function() {
+				return multiBuild(config, { minify: false, quiet: true });
+			})
+			.then(function() {
+				// each module that might be conditionally loaded once the
+				// built app is run on the browser gets its own module
+				return exists(path.join(bundles, "foo.js"));
+			});
+	});
+
 	function copyDependencies() {
 		var copy = denodeify(fs.copy);
 		var src = path.join(__dirname, "..", "node_modules");
@@ -181,7 +201,8 @@ describe("build app using steal-conditional", function() {
 			path.join(basePath, "substitution"),
 			path.join(basePath, "substitution-ext"),
 			path.join(basePath, "substitution-tilde"),
-			path.join(basePath, "substitution-folders")
+			path.join(basePath, "substitution-folders"),
+			path.join(basePath, "condition-module")
 		];
 
 		var promises = folders.map(function(dest) {

--- a/test/conditionals/condition-module/cond.js
+++ b/test/conditionals/condition-module/cond.js
@@ -1,0 +1,1 @@
+module.exports = document.querySelectorAll("#app").length;

--- a/test/conditionals/condition-module/foo.js
+++ b/test/conditionals/condition-module/foo.js
@@ -1,0 +1,1 @@
+export const variable = window.variable = "foo";

--- a/test/conditionals/condition-module/index.html
+++ b/test/conditionals/condition-module/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title>conditional modules build</title>
+	</head>
+	<body>
+	<script data-main="conditionals/main"
+			data-env="production"
+			data-config="package.json!npm"
+			src="../../../node_modules/steal/steal.js">
+		</script>
+	</body>
+</html>

--- a/test/conditionals/condition-module/main.js
+++ b/test/conditionals/condition-module/main.js
@@ -1,0 +1,1 @@
+require("foo#?cond");

--- a/test/conditionals/condition-module/package.json
+++ b/test/conditionals/condition-module/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "conditionals",
+  "version": "0.0.1",
+  "description": "",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "steal-conditional": "^0.3.4"
+  },
+  "system": {
+    "configDependencies": [
+      "./node_modules/steal-conditional/conditional"
+    ]
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
The condition module should not be evaluated during build, otherwise Browser specific code will break the build.

Related to https://github.com/stealjs/steal-conditional/issues/42

The test scenario for https://github.com/stealjs/steal-conditional/pull/46

- [x] Merge https://github.com/stealjs/steal-conditional/pull/46
- [x] Patch release steal-conditional
- [x] Update steal-conditional version in steal-tools' package.json
- [ ] Merge this PR once chances are made. 