### PR TITLE
Enable minification in the slim build stream

### DIFF
--- a/lib/build/slim.js
+++ b/lib/build/slim.js
@@ -1,8 +1,11 @@
 var pump = require("pump");
+var assign = require("lodash/assign");
+var isUndefined = require("lodash/isUndefined");
 var assignDefaultOptions = require("../assign_default_options");
 
 var streams = {
 	bundle: require("../stream/bundle"),
+	minify: require("../stream/minify"),
 	slimBundles: require("../stream/slim"),
 	transpile: require("../stream/transpile"),
 	concat: require("../bundle/concat_stream"),
@@ -17,17 +20,22 @@ var streams = {
 };
 
 module.exports = function(config, options) {
-	if (!options) options = {};
+	var buildOptions = assign({}, options);
+
+	// minification is on by default
+	assign(buildOptions, {
+		minify: isUndefined(buildOptions.minify) ? true : buildOptions.minify
+	});
 
 	try {
-		options = assignDefaultOptions(config, options);
+		options = assignDefaultOptions(config, buildOptions);
 	} catch (err) {
 		return Promise.reject(err);
 	}
 
 	return new Promise(function(resolve, reject) {
 		var writeSteam = pump(
-			streams.graph(config, options),
+			streams.graph(config, buildOptions),
 			streams.filterGraph(),
 			streams.checkSlimSupport(),
 			streams.addModuleIds(),
@@ -37,6 +45,7 @@ module.exports = function(config, options) {
 			streams.addBundleIds(),
 			streams.slimBundles(),
 			streams.concat(),
+			streams.minify(),
 			streams.write(),
 			streams.writeBundlesManifest(),
 			reject

--- a/lib/graph/slim_graph.js
+++ b/lib/graph/slim_graph.js
@@ -13,7 +13,7 @@ module.exports = function(options) {
 	var otherBundles = options.bundles.filter(negate(isJavaScriptBundle));
 
 	// filter out config nodes from the main bundle
-	jsBundles[0] = filterMainBundleNodes(jsBundles[0]);
+	jsBundles[0] = filterMainBundleNodes(options.configMain, jsBundles[0]);
 
 	var slimConfigNode = makeSlimConfigNode({
 		graph: options.graph,
@@ -85,14 +85,12 @@ function makeLoaderBundle(nodes) {
 	return bundle;
 }
 
-function filterMainBundleNodes(mainBundle) {
+function filterMainBundleNodes(configMain, mainBundle) {
 	var cloned = cloneDeep(mainBundle);
+	var blacklist = [configMain , "[system-bundles-config]"];
 
 	cloned.nodes = cloned.nodes.filter(function(node) {
-		return !includes(
-			["[system-bundles-config]", "package.json!npm"],
-			node.load.name
-		);
+		return !includes(blacklist, node.load.name);
 	});
 
 	return cloned;

--- a/lib/stream/slim.js
+++ b/lib/stream/slim.js
@@ -19,7 +19,8 @@ function doSlimGrap(data) {
 		mainModuleId: getMainModuleId(data),
 		splitLoader: data.options.splitLoader,
 		progressiveBundles: data.loader.bundle,
-		bundlesPath: data.configuration.bundlesPath
+		bundlesPath: data.configuration.bundlesPath,
+		configMain: data.loader.configMain || "package.json!npm"
 	});
 
 	return data;


### PR DESCRIPTION
Closes #748 

@matthewp I had to push the minification down the stream right before the bundles are written out, the reason being "slim nodes" will be minified to empty source since the minifier sees them as unused array declarations.

The downside of this is that bundles are going to be computed with the raw source, what do you think?