### PR TITLE
Return module exports from cache (instead of `module`)

### DIFF
--- a/lib/node/slim/make_shim_template.js
+++ b/lib/node/slim/make_shim_template.js
@@ -21,7 +21,7 @@ module.exports = function(options) {
 
 			function stealRequire(moduleId) {
 				if (loadedModules[moduleId]) {
-					return loadedModules[moduleId];
+					return stealRequire.esm(loadedModules[moduleId].exports);
 				}
 
 				${options.plugins ? slimPluginsPartial : ""}
@@ -37,8 +37,13 @@ module.exports = function(options) {
 					stealModule
 				);
 
-				return stealModule.exports;
+				return stealRequire.esm(stealModule.exports);
 			}
+
+			stealRequire.esm = function(stealExports) {
+				return stealExports && stealExports.__esModule ?
+					stealExports.default : stealExports;
+			};
 
 			${options.progressive ? progressivePartial : ""}
 

--- a/test/slim/cache/bar.js
+++ b/test/slim/cache/bar.js
@@ -1,0 +1,3 @@
+var util = require("./util");
+
+util("bar");

--- a/test/slim/cache/foo.js
+++ b/test/slim/cache/foo.js
@@ -1,0 +1,3 @@
+var util = require("./util");
+
+util("foo");

--- a/test/slim/cache/index.html
+++ b/test/slim/cache/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title></title>
+</head>
+<body>
+	<script src="./dist/bundles/main.js"></script>
+</body>
+</html>

--- a/test/slim/cache/main.js
+++ b/test/slim/cache/main.js
@@ -1,0 +1,2 @@
+require("./foo");
+require("./bar");

--- a/test/slim/cache/stealconfig.js
+++ b/test/slim/cache/stealconfig.js
@@ -1,0 +1,3 @@
+steal.config({
+	main: "main"
+});

--- a/test/slim/cache/util.js
+++ b/test/slim/cache/util.js
@@ -1,0 +1,5 @@
+export default function(prop) {
+	var _props = window._props || {};
+	_props[prop] = prop;
+	window._props = _props;
+};

--- a/test/slim_build_test.js
+++ b/test/slim_build_test.js
@@ -249,4 +249,27 @@ describe("slim builds", function() {
 				data[0]();
 			});
 	});
+
+	it("loader serves module from cache correctly", function() {
+		var base = path.join(__dirname, "slim", "cache");
+		var config = { config: path.join(base, "stealconfig.js") };
+
+		return rmdir(path.join(base, "dist"))
+			.then(function() {
+				return slim(config, { quiet: true, minify: false });
+			})
+			.then(function() {
+				return open(path.join("test", "slim", "cache", "index.html"));
+			})
+			.then(function(args) {
+				return Promise.all([args.close, find(args.browser, "_props")]);
+			})
+			.then(function(data) {
+				assert.deepEqual(data[1], {
+					foo: "foo",
+					bar: "bar"
+				}, "module cache works");
+				data[0]();
+			});
+	});
 });


### PR DESCRIPTION
Closes #751

The weather widget is working with this version 😭 

![google chrome](https://user-images.githubusercontent.com/724877/27457510-4395a368-5762-11e7-9029-583ec042aa64.png)
