### PR TITLE
Flag bundles as LOADED even if not required

### DIFF
--- a/lib/node/slim/make_shim_template.js
+++ b/lib/node/slim/make_shim_template.js
@@ -15,6 +15,8 @@ module.exports = function(options) {
 			var modulesMap = {};
 			var loadedModules = {};
 
+			/*globals steal, __steal_bundles__*/
+
 			function addModules(mods) {
 				mods.forEach(function(m) { modulesMap[m[0]] = m[1]; });
 			}

--- a/lib/node/slim/progressive_loader_partial.js
+++ b/lib/node/slim/progressive_loader_partial.js
@@ -24,9 +24,9 @@ __steal_bundles__.push = function(bundle) {
 
 	if (loadedBundles[bundleId]) {
 		resolves.push(loadedBundles[bundleId].resolve);
-		loadedBundles[bundleId] = LOADED;
 	}
 
+	loadedBundles[bundleId] = LOADED;
 	addModules(bundleModules);
 
 	// resolve each promise, first in first out

--- a/test/slim/async/bar.js
+++ b/test/slim/async/bar.js
@@ -1,0 +1,1 @@
+module.exports = function bar() {};

--- a/test/slim/async/baz.js
+++ b/test/slim/async/baz.js
@@ -1,0 +1,6 @@
+var foo = require("foo");
+
+module.exports = function baz() {
+	window.baz = "baz";
+	return foo();
+};

--- a/test/slim/async/foo.js
+++ b/test/slim/async/foo.js
@@ -1,0 +1,3 @@
+module.exports = function foo() {
+	console.log("foo executed!");
+};

--- a/test/slim/async/index.html
+++ b/test/slim/async/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title></title>
+</head>
+<body>
+	<script src="./dist/bundles/main.js"></script>
+	<script async src="./dist/bundles/baz.js"></script>
+</body>
+</html>

--- a/test/slim/async/main.js
+++ b/test/slim/async/main.js
@@ -1,0 +1,13 @@
+var bar = require("./bar");
+
+bar();
+
+setTimeout(
+	function() {
+		steal.import("baz").then(function(baz) {
+			console.log("baz loaded");
+			baz();
+		});
+	},
+	100
+);

--- a/test/slim/async/stealconfig.js
+++ b/test/slim/async/stealconfig.js
@@ -1,0 +1,5 @@
+steal.config({
+	name: "progressive",
+	main: "main",
+	bundle: ["baz"]
+});

--- a/test/slim_build_test.js
+++ b/test/slim_build_test.js
@@ -313,4 +313,27 @@ describe("slim builds", function() {
 				);
 			});
 	});
+
+	it("works with async progressively loaded bundles", function() {
+		var base = path.join(__dirname, "slim", "async");
+		var config = { config: path.join(base, "stealconfig.js") };
+
+		// allow `find` to reject before mocha timeout kicks in
+		this.timeout(3000);
+
+		return rmdir(path.join(base, "dist"))
+			.then(function() {
+				return slim(config, { quiet: true, minify: false });
+			})
+			.then(function() {
+				return open(path.join("test", "slim", "async", "index.html"));
+			})
+			.then(function(args) {
+				return Promise.all([args.close, find(args.browser, "baz")]);
+			})
+			.then(function(data) {
+				assert.equal(data[1], "baz", "progressively loaded baz correctly");
+				data[0]();
+			});
+	});
 });


### PR DESCRIPTION
The slim loader was only flagging bundles as loaded if the bundles were already required; that caused lazy loaded bundles to not resolve correctly.

Closes #763