### PR TITLE
Use non-normalize bundle names in slim config

### DIFF
--- a/doc/guides/optimized_builds.md
+++ b/doc/guides/optimized_builds.md
@@ -8,7 +8,7 @@ as the default way of creating a build of a module and all of its dependencies; 
 
 Unlike regular [builds](steal-tools.build), optimized builds don't need to load or bundle StealJS at all; a thin wrapper is added instead to the main bundle so the browser can load and execute the modules correctly. 
 
-> The **optimize** API is still a work in progress, some StealJS features are still not supported.
+> The **optimize** API is a work in progress, some StealJS features are not supported yet.
 
 In this guide, we'll go through the steps required to create and use an optimized build. We'll be using the
 `myhub` application created in the [Progressive Loading](./StealJS.guides.progressive_loading) guide.
@@ -38,7 +38,7 @@ Run the following command:
 ### Install dependencies
 
 As mentioned before, the **optimize** API is still in its early days, for that reason 
-we need to use the pre-release packages of `steal-tools` and `steal-css`.
+we need to use some pre-release packages.
 
 Edit your `package.json` like:
 
@@ -46,27 +46,11 @@ Edit your `package.json` like:
 "devDependencies": {
   ...
   "steal-css": "^1.3.0-pre.0",
-  "steal-tools": "^1.4.0-pre.1"
+  "steal-tools": "^1.4.0"
 }
 ```
 
 Run `npm install` to install all the application dependencies.
-
-### Update dynamic module identifiers
-
-One limitation of the optimized loader is that unlike StealJS's loader it does not normalize
-module identifiers on runtime. For static imports that's not a problem, but it's an issue for 
-dynamic imports (through `steal.import`), a workaround for that is to use the full module
-name.
-
-Edit the dynamic import in `myhub.js` to:
-
-```js
-steal.import(`myhub@1.0.0#${hash}/${hash}`).then(function(moduleOrPlugin) {
-```
-
-where "myhub" is the package name, the number after the "@" symbol is the package version and
-the rest of the string after the "#" is the actual module identifier.
 
 ### Make an optimize build script
 
@@ -89,6 +73,8 @@ Run the build script with:
 
 Now, start an http server by running `npm start` and open `http://127.0.0.1:8080/`
 in a web browser. You should see myhub's home page.
+
+> One limitation of the optimized loader is that unlike StealJS' loader it does not normalize module identifiers on runtime. For static imports that's not a problem, but it's an issue for dynamic imports (through steal.import), the module identifier needs to match the name set in [config.bundle].
 
 ### Performance comparison
 
@@ -119,7 +105,7 @@ Edit `index.html` to asynchronously load the bundles of the other two pages like
 ```html
 <body>
   <div class="container">Hello World.</div>
-  <script src="./dist/bundles/myhub/myhub.js"></script>
+  <script async src="./dist/bundles/myhub/myhub.js"></script>
   <script async src="./dist/bundles/myhub/weather/weather.js"></script>
   <script async src="./dist/bundles/myhub/puppies/puppies.js"></script>
 </body>

--- a/lib/node/make_slim_config_node.js
+++ b/lib/node/make_slim_config_node.js
@@ -55,9 +55,9 @@ module.exports = function(options) {
 		});
 	});
 
-	options.progressiveBundles.forEach(function(bundleName) {
-		var node = options.graph[bundleName];
-		slimMapConfig[bundleName] = node.load.uniqueId;
+	// [{ id : number, name : string }]
+	options.progressiveBundles.forEach(function(bundle) {
+		slimMapConfig[bundle.name] = bundle.id;
 	});
 
 	var configSource = `

--- a/lib/stream/slim.js
+++ b/lib/stream/slim.js
@@ -11,6 +11,11 @@ module.exports = function() {
 	});
 };
 
+/**
+ * Turns the bundles into their slim version (mutates stream data)
+ * @param {Object} data - The slim stream data object
+ * @return {Object} The mutated data
+ */
 function doSlimGrap(data) {
 	data.bundles = slimGraph({
 		graph: data.graph,
@@ -18,16 +23,41 @@ function doSlimGrap(data) {
 		baseUrl: data.loader.baseURL,
 		mainModuleId: getMainModuleId(data),
 		splitLoader: data.options.splitLoader,
-		progressiveBundles: data.loader.bundle,
 		bundlesPath: data.configuration.bundlesPath,
-		configMain: data.loader.configMain || "package.json!npm"
+		configMain: data.loader.configMain || "package.json!npm",
+		progressiveBundles: getProgressiveBundles(data.loader, data.graph)
 	});
 
 	return data;
 }
 
-
+/**
+ * Return the main module slim id
+ * @param {Object} data - The slim stream data object
+ * @return {number} The slim id
+ */
 function getMainModuleId(data) {
 	var mainName = data.mains[0];
 	return data.graph[mainName].load.uniqueId;
+}
+
+/**
+ * An array of module names/ids to be progressively loaded
+ * @param {Object} loader - The loader instance
+ * @param {Object} graph - The dependency graph
+ * @return {Array.<number, string>} List of module names and ids
+ */
+function getProgressiveBundles(loader, graph) {
+	var config = loader.__loaderConfig || {};
+	var configBundle = config.bundle || [];
+
+	return loader.bundle.map(function(name, index) {
+		return {
+			id: graph[name].load.uniqueId,
+
+			// use the raw module identifiers so the user won't have to use
+			// the full normalized names when importing a module dynamically
+			name: configBundle[index] || name
+		};
+	});
 }


### PR DESCRIPTION
Closes #759 

This way the slim user won't have to use full bundle names when dynamic importing stuff.