### PR TITLE
Add options to target NodeJS for slim bundles

### DIFF
--- a/lib/arrify.js
+++ b/lib/arrify.js
@@ -1,0 +1,14 @@
+var isArray = require("lodash/isArray");
+
+/**
+ * Converts a value to an array
+ * @param {*} value - The value to convert
+ * @return {Array}
+ */
+module.exports = function arrify(value) {
+	if (value == null) {
+		return [];
+	}
+
+	return isArray(value) ? value : [value];
+};

--- a/lib/build/slim.js
+++ b/lib/build/slim.js
@@ -1,27 +1,31 @@
 var pump = require("pump");
+var arrify = require("../arrify");
 var assign = require("lodash/assign");
+var makeDeferred = require("../make-deferred");
 var isUndefined = require("lodash/isUndefined");
 var assignDefaultOptions = require("../assign_default_options");
 
-var streams = {
-	bundle: require("../stream/bundle"),
-	minify: require("../stream/minify"),
-	slimBundles: require("../stream/slim"),
-	transpile: require("../stream/transpile"),
-	concat: require("../bundle/concat_stream"),
-	addModuleIds: require("../stream/add_module_ids"),
-	addBundleIds: require("../stream/add_bundle_ids"),
-	filterGraph: require("../stream/filter_slim_graph"),
-	addPluginNames: require("../stream/add_plugin_names"),
-	addAtLoaderShim: require("../stream/add_loader_shim"),
-	checkSlimSupport: require("../stream/check_slim_support"),
-	write: require("../bundle/write_bundles").createWriteStream,
-	writeBundlesManifest: require("../stream/write_bundle_manifest"),
-	loadOptimizedPlugins: require("../stream/load_optimized_plugins"),
-	graph: require("../graph/make_graph_with_bundles").createBundleGraphStream
-};
+// streams
+var bundle = require("../stream/bundle");
+var minify = require("../stream/minify");
+var slimBundles = require("../stream/slim");
+var transpile = require("../stream/transpile");
+var concat = require("../bundle/concat_stream");
+var addModuleIds = require("../stream/add_module_ids");
+var addBundleIds = require("../stream/add_bundle_ids");
+var filterGraph = require("../stream/filter_slim_graph");
+var addPluginNames = require("../stream/add_plugin_names");
+var addAtLoaderShim = require("../stream/add_loader_shim");
+var cloneBuildData = require("../stream/clone_build_data");
+var checkSlimSupport = require("../stream/check_slim_support");
+var adjustBundlesPath = require("../stream/adjust_bundles_path");
+var write = require("../bundle/write_bundles").createWriteStream;
+var writeBundlesManifest = require("../stream/write_bundle_manifest");
+var loadOptimizedPlugins = require("../stream/load_optimized_plugins");
+var graph = require("../graph/make_graph_with_bundles").createBundleGraphStream;
 
 module.exports = function(config, options) {
+	var slimDfd = makeDeferred();
 	var buildOptions = assign({}, options);
 
 	// minification is on by default
@@ -35,26 +39,64 @@ module.exports = function(config, options) {
 		return Promise.reject(err);
 	}
 
-	return new Promise(function(resolve, reject) {
-		var writeSteam = pump(
-			streams.graph(config, buildOptions),
-			streams.filterGraph(),
-			streams.checkSlimSupport(),
-			streams.addAtLoaderShim(),
-			streams.addModuleIds(),
-			streams.loadOptimizedPlugins(),
-			streams.transpile({ outputFormat: "slim" }),
-			streams.bundle(),
-			streams.addPluginNames(),
-			streams.addBundleIds(),
-			streams.slimBundles(),
-			streams.concat(),
-			streams.minify(),
-			streams.write(),
-			streams.writeBundlesManifest(),
-			reject
+	var initialStream = pump(
+		graph(config, buildOptions),
+		filterGraph(),
+		checkSlimSupport(),
+		addAtLoaderShim(),
+		addModuleIds(),
+		loadOptimizedPlugins(),
+		transpile({ outputFormat: "slim" }),
+		bundle(),
+		addPluginNames(),
+		addBundleIds(),
+		function(err) {
+			if (err) slimDfd.reject(err);
+		}
+	);
+
+	var targets = arrify(buildOptions.target);
+	var promises = (targets.length ? targets : [""]).map(function(target) {
+		var dfd = makeDeferred();
+
+		var final = pump(
+			initialStream,
+			cloneBuildData(),
+			adjustBundlesPath({ target: target }),
+			slimBundles({ target: target }),
+			concat(),
+			minify(),
+			write(),
+			writeBundlesManifest(),
+			function(err) {
+				if (err) dfd.reject(err);
+			}
 		);
 
-		writeSteam.on("data", resolve);
+		final.on("data", dfd.resolve);
+		return dfd.promise;
 	});
+
+	Promise.all(promises).then(
+		// If no `target` is provided resolves `buildResult`; otherwise
+		// resolves an object where the key is the target name and its value
+		// the `buildResult` object.
+		function(results) {
+			var value;
+
+			if (targets.length) {
+				value = {};
+				results.forEach(function(result, index) {
+					value[targets[index]] = result;
+				});
+			} else {
+				value = results[0];
+			}
+
+			slimDfd.resolve(value);
+		},
+		slimDfd.reject
+	);
+
+	return slimDfd.promise;
 };

--- a/lib/bundle/write_bundles.js
+++ b/lib/bundle/write_bundles.js
@@ -1,6 +1,3 @@
-// # lib/bundle/write_bundles.js
-// Given an array of bundles and the baseURL
-// Writes them out to the file system.
 var bundleFilename = require("./filename");
 var dirname = require("path").dirname;
 var addSourceMapUrl = require("../bundle/add_source_map_url");
@@ -12,6 +9,12 @@ var denodeify = require("pdenodeify");
 var writeFile = denodeify(require("fs").writeFile);
 var mkdirp = denodeify(require("fs-extra").mkdirp);
 
+/**
+ * Writes bundles out to the file system.
+ * @param {Array} bundles - The bundles to be written out
+ * @param {Object} configuration - The build configuration object
+ * @return {Promise.<bundle[]>} A promise that resolves when bundles finished writing
+ */
 var writeBundles = module.exports = function(bundles, configuration) {
 	// Create the bundle directory
 	var bundleDirDef = configuration.mkBundlesPathDir();
@@ -69,7 +72,12 @@ var writeBundles = module.exports = function(bundles, configuration) {
 	return Promise.all(bundles.map(processBundle));
 };
 
-writeBundles.createWriteStream = function(){
+/**
+ * Transform stream that writes the bundles to the filesystem
+ * @param {Object} [options] - An object of options
+ * @return {stream.Transform}
+ */
+writeBundles.createWriteStream = function() {
 	function write(buildResult, enc, done) {
 		var configuration = buildResult.configuration;
 		var bundles = buildResult.bundles;

--- a/lib/configuration/make.js
+++ b/lib/configuration/make.js
@@ -63,11 +63,3 @@ Configuration.prototype = {
 		return this.loader.configMain || "@config";
 	}
 };
-
-
-
-
-
-
-
-

--- a/lib/graph/slim_graph.js
+++ b/lib/graph/slim_graph.js
@@ -1,5 +1,6 @@
 var negate = require("lodash/negate");
 var concat = require("lodash/concat");
+var partial = require("lodash/partial");
 var includes = require("lodash/includes");
 var cloneDeep = require("lodash/cloneDeep");
 var isJavaScriptBundle = require("../bundle/is_js_bundle");
@@ -29,6 +30,7 @@ module.exports = function(options) {
 		});
 
 	var slimConfigNode = makeSlimConfigNode({
+		target: options.target,
 		graph: options.graph,
 		baseUrl: options.baseUrl,
 		bundles: options.bundles, // the config needs to receive all the bundles
@@ -44,6 +46,7 @@ module.exports = function(options) {
 					nodes: [],
 					splitLoader: true,
 					progressive: true,
+					target: options.target,
 					plugins: !!otherBundles.length,
 					mainModuleId: options.mainModuleId
 				})
@@ -52,7 +55,7 @@ module.exports = function(options) {
 
 		slimmedBundles = concat(
 			loaderBundle,
-			jsBundles.map(toSlimBundle),
+			jsBundles.map(partial(toSlimBundle, options.target)),
 			otherBundles
 		);
 	} else {
@@ -62,6 +65,7 @@ module.exports = function(options) {
 		mainBundle.nodes = [
 			slimConfigNode,
 			makeSlimShimNode({
+				target: options.target,
 				nodes: mainBundle.nodes,
 				plugins: !!otherBundles.length,
 				progressive: !!jsBundles.length,
@@ -71,7 +75,7 @@ module.exports = function(options) {
 
 		slimmedBundles = concat(
 			mainBundle,
-			jsBundles.map(toSlimBundle),
+			jsBundles.map(partial(toSlimBundle, options.target)),
 			otherBundles
 		);
 	}
@@ -79,9 +83,9 @@ module.exports = function(options) {
 	return slimmedBundles;
 };
 
-function toSlimBundle(bundle) {
+function toSlimBundle(target, bundle) {
 	var cloned = cloneDeep(bundle);
-	cloned.nodes = [makeSlimBundleNode(cloned)];
+	cloned.nodes = [makeSlimBundleNode(target, cloned)];
 	return cloned;
 }
 

--- a/lib/node/make_slim_bundle_node.js
+++ b/lib/node/make_slim_bundle_node.js
@@ -1,12 +1,12 @@
 var prettier = require("prettier");
 var makeBundleCode = require("./slim/make_bundle_code");
 
-module.exports = function(bundle) {
+module.exports = function(target, bundle) {
 	return {
 		load: {
 			name: bundle.name,
 			metadata: { format: "global" },
-			source: prettier.format(makeBundleCode(bundle), { useTabs: true })
+			source: prettier.format(makeBundleCode(target, bundle), { useTabs: true })
 		},
 		dependencies: [],
 		deps: []

--- a/lib/node/make_slim_config_node.js
+++ b/lib/node/make_slim_config_node.js
@@ -19,26 +19,31 @@ module.exports = function(options) {
 	var slimPluginsConfig = {};
 
 	/**
-	 * Returns then bundle's path relative to the loader baseUrl
+	 * Returns the bundle's path
 	 *
-	 * The bundles path at this point is an absolute file url, the relative
-	 * version is needed in the written config so the loader can use script
-	 * tags to load the bundles during runtime.
+	 * For nodejs, the name of the bundle is returned since `require` will
+	 * locate the bundle relative to the main module folder.
 	 *
+	 * For the web, a relative path to the loader baseUrl is returned, so the
+	 * loader can use script tags to load the bundles during runtime.
+	 *
+	 * @param {string} target - The name of the build target (node, web)
 	 * @param {Object} bundle - The bundle object
 	 * @return {string} the relative path
 	 */
-	function getRelativeBundlePath(bundle) {
+	function getRelativeBundlePath(target, bundle) {
 		var baseUrl = options.baseUrl.replace("file:", "");
 
-		return path.join(
-			path.relative(baseUrl, options.bundlesPath),
-			getBundleFileName(bundle)
-		);
+		return target === "node" ?
+			getBundleFileName(bundle) :
+			path.join(
+				path.relative(baseUrl, options.bundlesPath),
+				getBundleFileName(bundle)
+			);
 	}
 
 	bundles.forEach(function(bundle) {
-		slimPathsConfig[bundle.uniqueId] = getRelativeBundlePath(bundle);
+		slimPathsConfig[bundle.uniqueId] = getRelativeBundlePath(options.target, bundle);
 
 		if (bundle.pluginName) {
 			var pluginNode = options.graph[bundle.pluginName];
@@ -69,7 +74,7 @@ module.exports = function(options) {
 			global.steal.bundles = ${JSON.stringify(slimBundlesConfig)};
 			global.steal.plugins = ${JSON.stringify(slimPluginsConfig)};
 
-		}(window));
+		}(${ options.target === "node" ? "global" : "window" }));
 	`;
 
 	return {

--- a/lib/node/make_slim_shim_node.js
+++ b/lib/node/make_slim_shim_node.js
@@ -7,6 +7,7 @@ module.exports = function(options) {
 	var modules = options.nodes.slice(0);
 
 	var template = makeShimTemplate({
+		target: options.target,
 		plugins: options.plugins,
 		splitLoader: options.splitLoader,
 		progressive: options.progressive

--- a/lib/node/slim/bundle.js
+++ b/lib/node/slim/bundle.js
@@ -1,8 +1,0 @@
-var template = require("lodash/template");
-
-module.exports = template(`
-	(__steal_bundles__ = window.__steal_bundles__ || []).push([
-		<%= bundleId %>,
-		<%= bundleNodes %>
-	]);
-`);

--- a/lib/node/slim/make_bundle_code.js
+++ b/lib/node/slim/make_bundle_code.js
@@ -1,8 +1,7 @@
 var endsWith = require("lodash/endsWith");
-var slimBundleTemplate = require("./bundle");
 var getNodeSource = require("../source").node;
 
-module.exports = function(bundle) {
+module.exports = function(target, bundle) {
 	var nodes = bundle.nodes
 		.map(function(node) {
 			var code = getNodeSource(node).code.toString();
@@ -10,8 +9,14 @@ module.exports = function(bundle) {
 		})
 		.join(",");
 
-	return slimBundleTemplate({
-		bundleId: bundle.uniqueId,
-		bundleNodes: nodes
-	});
+	if (target === "node") {
+		return `module.exports = [${bundle.uniqueId}, ${nodes}];`;
+	} else {
+		return (`
+			(__steal_bundles__ = window.__steal_bundles__ || []).push([
+				${ bundle.uniqueId },
+				${ nodes }
+			]);
+		`);
+	}
 };

--- a/lib/node/slim/make_shim_template.js
+++ b/lib/node/slim/make_shim_template.js
@@ -1,21 +1,27 @@
 var template = require("lodash/template");
-var progressivePartial = require("./progressive_loader_partial");
 
-var slimPluginsPartial = `
+var slimPluginsPartial = (`
 	// delegate loading non plain JS modules to plugins
 	var pluginModuleId = steal.plugins[steal.bundles[moduleId]];
 	if (pluginModuleId) {
 		return stealRequire(pluginModuleId)(moduleId, steal);
 	}
-`;
+`);
+
+var renderProgressivePartial = function(options) {
+	if (options.progressive) {
+		var partials = require("./progressive_loader_partial");
+		return options.target === "node" ? partials.node : partials.web;
+	} else {
+		return "";
+	}
+};
 
 module.exports = function(options) {
 	return template(`
 		(function(modules) {
 			var modulesMap = {};
 			var loadedModules = {};
-
-			/*globals steal, __steal_bundles__*/
 
 			function addModules(mods) {
 				mods.forEach(function(m) { modulesMap[m[0]] = m[1]; });
@@ -43,14 +49,18 @@ module.exports = function(options) {
 				return stealModule.exports;
 			}
 
-			${options.progressive ? progressivePartial : ""}
+			${renderProgressivePartial(options)}
 
 			// import the main module
-			${options.splitLoader ?
-				"stealRequire.dynamic(<%= mainModuleId  %>);" :
-				"stealRequire(<%= mainModuleId  %>);"}
+			${options.target === "node" ? "module.exports = " : "" } ${
+				options.splitLoader ?
+					"stealRequire.dynamic(<%= mainModuleId  %>);" :
+					"stealRequire(<%= mainModuleId  %>);"
+			}
 		})([
 			<%= args %>
 		]);
 	`);
 };
+
+

--- a/lib/node/slim/progressive_loader_partial.js
+++ b/lib/node/slim/progressive_loader_partial.js
@@ -1,132 +1,156 @@
-module.exports = (`
-// extends the loader to support progressive/async loading
-var LOADED = 0;
-var resolves = [];
-var loadedBundles = {};
-var SCRIPT_TIMEOUT = 120000;
+module.exports = {
+	node: `
+		var LOADED = 0;
+		var loadedBundles = {};
+		stealRequire.dynamic = function(rawModuleId) {
+			var moduleId = steal.map[rawModuleId] || rawModuleId;
+			var bundleId = steal.bundles[moduleId];
 
-// bundles are pushed to this array during eval
-__steal_bundles__ = window.__steal_bundles__ || [];
-
-// register bundles executed before the main bundle finished loading
-__steal_bundles__.forEach(function(bundle) {
-	var bundleId = bundle[0];
-	var bundleModules = bundle.slice(1);
-
-	addModules(bundleModules);
-	loadedBundles[bundleId] = LOADED;
-});
-
-// handle bundles loading after main has loaded
-__steal_bundles__.push = function(bundle) {
-	var bundleId = bundle[0];
-	var bundleModules = bundle.slice(1);
-
-	if (loadedBundles[bundleId]) {
-		resolves.push(loadedBundles[bundleId].resolve);
-	}
-
-	loadedBundles[bundleId] = LOADED;
-	addModules(bundleModules);
-
-	// resolve each promise, first in first out
-	while (resolves.length)
-		resolves.shift()();
-	return Array.prototype.push.call(this, bundle);
-};
-
-stealRequire.dynamic = function(rawModuleId) {
-	var moduleId = steal.map[rawModuleId] || rawModuleId;
-	var bundleId = steal.bundles[moduleId];
-
-	if (!bundleId) {
-		throw new Error("Missing bundle for module with id: " + moduleId);
-	}
-
-	// if the bundle has been loaded already,
-	// return a promise that resolves to the module being imported
-	if (loadedBundles[bundleId] === LOADED) {
-		return Promise.resolve(stealRequire(moduleId));
-	}
-
-	// the bundle is loading, return its promise
-	if (loadedBundles[bundleId]) {
-		return loadedBundles[bundleId].promise.then(function() {
-			return stealRequire(moduleId);
-		});
-	}
-
-	// add deferred to the bundles cache
-	var deferred = makeDeferred();
-	loadedBundles[bundleId] = deferred;
-
-	// check if the bundle is being loaded using a script tag
-	var script = getBundleScript(steal.paths[bundleId]);
-	var scriptAttached = true;
-
-	// load the bundle using a script tag otherwise
-	if (!script) {
-		script = makeScript();
-		script.src = steal.paths[bundleId];
-		scriptAttached = false;
-	}
-
-	var head = document.getElementsByTagName("head")[0];
-	var timeout = setTimeout(onScriptLoad, SCRIPT_TIMEOUT);
-
-	function onScriptLoad() {
-		// avoid memory leaks in IE.
-		script.onerror = script.onload = null;
-		clearTimeout(timeout);
-
-		var bundle = loadedBundles[bundleId];
-		if (bundle !== LOADED) {
-			if (bundle) {
-				bundle.reject(
-					new Error("Failed to load bundle with id: " + bundleId)
-				);
+			if (!bundleId) {
+				throw new Error("Missing bundle for module with id: " + moduleId);
 			}
-			loadedBundles[bundleId] = undefined;
-		}
-	}
 
-	if (!scriptAttached) head.appendChild(script);
-	return deferred.promise.then(function() {
-		return stealRequire(moduleId);
-	});
-};
+			if (loadedBundles[bundleId] !== LOADED) {
+				var bundle = require("./" + steal.paths[bundleId]);
 
-function makeScript() {
-	var script = document.createElement("script");
+				addModules(bundle.slice(1));
+				loadedBundles[bundleId] = LOADED;
+			}
 
-	script.type = "text/javascript";
-	script.charset = "utf-8";
-	script.async = true;
-	script.timeout = SCRIPT_TIMEOUT;
+			return Promise.resolve(stealRequire(moduleId));
+		};
+	`,
 
-	return script;
-}
+	web: `
+		// extends the loader to support progressive/async loading
+		var LOADED = 0;
+		var resolves = [];
+		var loadedBundles = {};
+		var SCRIPT_TIMEOUT = 120000;
 
-function makeDeferred() {
-	var def = Object.create(null);
+		// bundles are pushed to this array during eval
+		__steal_bundles__ = window.__steal_bundles__ || [];
 
-	def.promise = new Promise(function(resolve, reject) {
-		def.resolve = resolve;
-		def.reject = reject;
-	});
+		// register bundles executed before the main bundle finished loading
+		__steal_bundles__.forEach(function(bundle) {
+			var bundleId = bundle[0];
+			var bundleModules = bundle.slice(1);
 
-	return def;
-}
+			addModules(bundleModules);
+			loadedBundles[bundleId] = LOADED;
+		});
 
-function getBundleScript(src) {
-	var len = document.scripts.length;
+		// handle bundles loading after main has loaded
+		__steal_bundles__.push = function(bundle) {
+			var bundleId = bundle[0];
+			var bundleModules = bundle.slice(1);
 
-	for (var i = 0; i < len; i += 1) {
-		var script = document.scripts[i];
+			if (loadedBundles[bundleId]) {
+				resolves.push(loadedBundles[bundleId].resolve);
+			}
 
-		if (script.src.indexOf(src) !== -1) {
+			loadedBundles[bundleId] = LOADED;
+			addModules(bundleModules);
+
+			// resolve each promise, first in first out
+			while (resolves.length)
+				resolves.shift()();
+			return Array.prototype.push.call(this, bundle);
+		};
+
+		stealRequire.dynamic = function(rawModuleId) {
+			var moduleId = steal.map[rawModuleId] || rawModuleId;
+			var bundleId = steal.bundles[moduleId];
+
+			if (!bundleId) {
+				throw new Error("Missing bundle for module with id: " + moduleId);
+			}
+
+			// if the bundle has been loaded already,
+			// return a promise that resolves to the module being imported
+			if (loadedBundles[bundleId] === LOADED) {
+				return Promise.resolve(stealRequire(moduleId));
+			}
+
+			// the bundle is loading, return its promise
+			if (loadedBundles[bundleId]) {
+				return loadedBundles[bundleId].promise.then(function() {
+					return stealRequire(moduleId);
+				});
+			}
+
+			// add deferred to the bundles cache
+			var deferred = makeDeferred();
+			loadedBundles[bundleId] = deferred;
+
+			// check if the bundle is being loaded using a script tag
+			var script = getBundleScript(steal.paths[bundleId]);
+			var scriptAttached = true;
+
+			// load the bundle using a script tag otherwise
+			if (!script) {
+				script = makeScript();
+				script.src = steal.paths[bundleId];
+				scriptAttached = false;
+			}
+
+			var head = document.getElementsByTagName("head")[0];
+			var timeout = setTimeout(onScriptLoad, SCRIPT_TIMEOUT);
+
+			function onScriptLoad() {
+				// avoid memory leaks in IE.
+				script.onerror = script.onload = null;
+				clearTimeout(timeout);
+
+				var bundle = loadedBundles[bundleId];
+				if (bundle !== LOADED) {
+					if (bundle) {
+						bundle.reject(
+							new Error("Failed to load bundle with id: " + bundleId)
+						);
+					}
+					loadedBundles[bundleId] = undefined;
+				}
+			}
+
+			if (!scriptAttached) head.appendChild(script);
+			return deferred.promise.then(function() {
+				return stealRequire(moduleId);
+			});
+		};
+
+		function makeScript() {
+			var script = document.createElement("script");
+
+			script.type = "text/javascript";
+			script.charset = "utf-8";
+			script.async = true;
+			script.timeout = SCRIPT_TIMEOUT;
+
 			return script;
 		}
-	}
-}
-`);
+
+		function makeDeferred() {
+			var def = Object.create(null);
+
+			def.promise = new Promise(function(resolve, reject) {
+				def.resolve = resolve;
+				def.reject = reject;
+			});
+
+			return def;
+		}
+
+		function getBundleScript(src) {
+			var len = document.scripts.length;
+
+			for (var i = 0; i < len; i += 1) {
+				var script = document.scripts[i];
+
+				if (script.src.indexOf(src) !== -1) {
+					return script;
+				}
+			}
+		}
+	`
+};

--- a/lib/stream/adjust_bundles_path.js
+++ b/lib/stream/adjust_bundles_path.js
@@ -1,0 +1,29 @@
+var through = require("through2");
+
+module.exports = function(options) {
+	return through.obj(function(data, enc, next) {
+		try {
+			next(null, adjustBundlesPath(data, options));
+		} catch (err) {
+			next(err);
+		}
+	});
+};
+
+function adjustBundlesPath(data, options) {
+	if (options.target) {
+		var path = require("path");
+
+		// override the configuration getter for `bundlesPath` so it
+		// includes the target name
+		var bundlesPath = data.configuration.bundlesPath;
+		Object.defineProperty(data.configuration, "bundlesPath", {
+			configurable: true,
+			get: function() {
+				return path.join(bundlesPath, options.target);
+			}
+		});
+	}
+
+	return data;
+}

--- a/lib/stream/clone_build_data.js
+++ b/lib/stream/clone_build_data.js
@@ -1,0 +1,12 @@
+var through = require("through2");
+var clone = require("lodash/cloneDeep");
+
+module.exports = function() {
+	return through.obj(function(data, enc, next) {
+		try {
+			next(null, clone(data));
+		} catch (err) {
+			next(err);
+		}
+	});
+};

--- a/lib/stream/slim.js
+++ b/lib/stream/slim.js
@@ -1,10 +1,15 @@
 var through = require("through2");
 var slimGraph = require("../graph/slim_graph");
 
+/**
+ * @param {Object} options - An options object
+ */
 module.exports = function() {
+	var options = arguments[0] !== undefined ? arguments[0] : {};
+
 	return through.obj(function(data, enc, next) {
 		try {
-			next(null, doSlimGrap(data));
+			next(null, doSlimGrap(data, options));
 		} catch (err) {
 			next(err);
 		}
@@ -14,12 +19,14 @@ module.exports = function() {
 /**
  * Turns the bundles into their slim version (mutates stream data)
  * @param {Object} data - The slim stream data object
+ * @param {Object} options - An options object
  * @return {Object} The mutated data
  */
-function doSlimGrap(data) {
+function doSlimGrap(data, options) {
 	data.bundles = slimGraph({
 		graph: data.graph,
 		bundles: data.bundles,
+		target: options.target,
 		baseUrl: data.loader.baseURL,
 		mainModuleId: getMainModuleId(data),
 		splitLoader: data.options.splitLoader,

--- a/test/slim/basics/web.html
+++ b/test/slim/basics/web.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Web target output</title>
+</head>
+<body>
+	<script src="./dist/bundles/web/main.js"></script>
+</body>
+</html>

--- a/test/slim/node/progressive/foo.js
+++ b/test/slim/node/progressive/foo.js
@@ -1,0 +1,1 @@
+module.exports = "foo";

--- a/test/slim/node/progressive/main.js
+++ b/test/slim/node/progressive/main.js
@@ -1,0 +1,1 @@
+exports.foo = steal.import("./foo");

--- a/test/slim/node/progressive/stealconfig.js
+++ b/test/slim/node/progressive/stealconfig.js
@@ -1,0 +1,4 @@
+steal.config({
+	main: "main",
+	bundle: ["./foo"]
+});

--- a/test/slim/node/single/foo.js
+++ b/test/slim/node/single/foo.js
@@ -1,0 +1,1 @@
+module.exports = "foo";

--- a/test/slim/node/single/main.js
+++ b/test/slim/node/single/main.js
@@ -1,0 +1,1 @@
+exports.foo = require("./foo");

--- a/test/slim/node/single/stealconfig.js
+++ b/test/slim/node/single/stealconfig.js
@@ -1,0 +1,3 @@
+steal.config({
+	main: "main"
+});


### PR DESCRIPTION
Closes #719 

The docs for the new options are pending, will probably work on them once I finish working on the workers target.

@matthewp a couple of things

a) I changed the paths config for node so instead of being relative to the loader baseUrl, they are relative to the actual main file

```js
global.steal.paths = { "4": "main.js", "5": "foo.js" };
```
this is the only way I found to get the `require` to load bundles to work, thoughts?

b) The node slim loader still returns a promise when dynamically loading bundles, the reason being the transpiled dynamic imports expect a promise... We could go a step further and have transpile make those calls static, since bundles are loaded through `require`, not sure about this though.

c) when targets are provided, the buildResult objects are returned "labeled", the promise will resolve an object with this shape:

```js
{ web: { ...buildResult }, node: { ...buildResult } }
```
yay? nay?


