### PR TITLE
Prevent uglify to reduce vars it breaks lodash build

### DIFF
--- a/lib/assign_default_options.js
+++ b/lib/assign_default_options.js
@@ -10,7 +10,14 @@ module.exports = function(config, options){
 	options = assign({ // Defaults
 		minify: false,
 		bundleSteal: false,
-		uglifyOptions: {},
+		uglifyOptions: {
+			compress: {
+				reduce_vars: false
+			},
+			mangle: {
+				reserved: ["require"]
+			}
+		},
 		cleanCSSOptions: {
 			rebase: false,
 			inline: ["none"]

--- a/test/collapsed_vars/_memoizeCapped.js
+++ b/test/collapsed_vars/_memoizeCapped.js
@@ -1,0 +1,3 @@
+module.exports = function(cb) {
+	return cb();
+};

--- a/test/collapsed_vars/index.html
+++ b/test/collapsed_vars/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title></title>
+</head>
+<body>
+	<script src="./dist/steal.production.js"></script>
+</body>
+</html>

--- a/test/collapsed_vars/main.js
+++ b/test/collapsed_vars/main.js
@@ -1,0 +1,28 @@
+var memoizeCapped = require('./_memoizeCapped');
+
+/** Used to match property names within property paths. */
+var reLeadingDot = /^\./,
+    rePropName = /[^.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|$))/g;
+
+/** Used to match backslashes in property paths. */
+var reEscapeChar = /\\(\\)?/g;
+
+/**
+ * Converts `string` to a property path array.
+ *
+ * @private
+ * @param {string} string The string to convert.
+ * @returns {Array} Returns the property path array.
+ */
+var stringToPath = memoizeCapped(function(string) {
+  var result = [];
+  if (reLeadingDot.test(string)) {
+    result.push('');
+  }
+  string.replace(rePropName, function(match, number, quote, string) {
+    result.push(quote ? string.replace(reEscapeChar, '$1') : (number || match));
+  });
+  return result;
+});
+
+module.exports = stringToPath;

--- a/test/collapsed_vars/stealconfig.js
+++ b/test/collapsed_vars/stealconfig.js
@@ -1,0 +1,3 @@
+steal.config({
+	main: "main"
+});

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -2252,4 +2252,19 @@ describe("multi build", function(){
 				});
 			});
 	});
+
+    // https://github.com/stealjs/steal-tools/issues/563#issuecomment-316367213
+	it("collapsed require statements with unbalance quotes", function() {
+		var base = path.join(__dirname, "collapsed_vars");
+
+		return asap(rmdir)(path.join(base, "dist"))
+			.then(function() {
+				return multiBuild({
+					config: path.join(base, "stealconfig.js")
+				}, {
+					quiet: true,
+					dest: path.join(base, "dist")
+				});
+			});
+	});
 });


### PR DESCRIPTION
@matthewp 

Setting `compress.reduce_vars` to false "fixes" the build of the example app here 

https://github.com/stealjs/steal-tools/issues/563#issuecomment-316383978

but, it's a brittle solution, just moving around the `require` in the source files can trigger the issue again.... To replicate I had to copy/paste lodash module in my test. No idea how it decides when to put the require after the other variables.

James and Ryan tried to fix the regex but it's a hard problem when the code is minified, any unbalance quote before a require (in the same line) will break it. E.g

```js
var foo = `"`; bar = require("foo")`
```

or 

```js
var foo = /'/g; bar = require('foo')`
```

We could try to remove the es6 literals before detecting strings, but Regexes are more complicated because of the nested pairs `[]`, `()`. See https://stackoverflow.com/questions/172303/is-there-a-regular-expression-to-detect-a-valid-regular-expression and https://blogs.msdn.microsoft.com/jaredpar/2008/10/15/regular-expression-limitations/.

I tried beautifying the minified output using uglify's `beautify` option but that does not fix it, the beautifier has to be insert newlines in each var declaration so the bug does not appear.

Thoughts? (should I document these defaults before merging this PR if that's what we want to do?)



