### PR TITLE
Make 'target' property optional for optimize CLI

### DIFF
--- a/lib/cli/cmd_optimize.js
+++ b/lib/cli/cmd_optimize.js
@@ -26,8 +26,11 @@ var options = assign(
 		},
 		target: {
 			type: "array",
-			describe: "Specifies the platform where the application is going to be deployed",
-			choices: ["web", "node", "worker"]
+			demandOption: false,
+			describe: [
+				"Specifies the platform where the application is going to be deployed",
+				'[choices: "web", "node", "worker"]'
+			].join("\n")
 		}
 	}
 );

--- a/test/test_cli.js
+++ b/test/test_cli.js
@@ -398,5 +398,60 @@ describe("steal-tools cli", function () {
 					process.chdir(cwd);
 				});
 		});
+
+		it("'target' should be optional", function() {
+			var cwd = process.cwd();
+			var base = path.join(__dirname, "slim", "worker", "single");
+
+			process.chdir(base);
+
+			return asap(rmdir)(path.join(base, "dist"))
+				.then(function() {
+					return stealTools([
+						"optimize",
+						"--config", "stealconfig.js",
+						"--main", "main",
+						"--no-minify"
+					]);
+				})
+				.then(function() {
+					var bundles = path.join(base, "dist", "bundles");
+					return fileExists(path.join(bundles, "main.js"));
+				})
+				.then(function() {
+					process.chdir(cwd);
+				});
+		});
+	});
+
+	it("throws if an unknown 'target' is passed in", function(done) {
+		var cwd = process.cwd();
+		var base = path.join(__dirname, "slim", "worker", "single");
+
+		process.chdir(base);
+
+		asap(rmdir)(path.join(base, "dist"))
+			.then(function() {
+				return stealTools([
+					"optimize",
+					"--config", "stealconfig.js",
+					"--main", "main",
+					"--no-minify",
+					"--target", "foo"
+				]);
+			})
+			.then(
+				function() {
+					assert(false, "command should not succeed");
+				},
+				function(error) {
+					process.chdir(cwd);
+					assert(
+						/Cannot create slim build, target/.test(error.message),
+						"should throw a descriptive error message"
+					);
+				}
+			)
+			.then(done, done);
 	});
 });


### PR DESCRIPTION
Closes #809

Unfortunately there is yargs bug preventing me to use their API to make the array as optional, my ad-hoc solution was to copy their description including the possible values which is nice

![screen shot 2017-08-14 at 18 23 49](https://user-images.githubusercontent.com/724877/29297924-8bc1491a-8121-11e7-8a5b-3e820c3234d6.png)

But removed the `choices` property, the `optimize` method already validates `target` values. I put a test there just to make sure it works as intended. 