### PR TITLE
Make sure Steal does not break the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "pdenodeify": "^0.1.0",
     "prettier": "^1.3.1",
     "pump": "^1.0.2",
-    "steal": "^1.4.2",
+    "steal": "^1.5.8",
     "steal-bundler": "^0.3.0",
     "steal-parse-amd": "^1.0.0",
     "through2": "^2.0.0",


### PR DESCRIPTION
teal@1.5.7 introduced an issue affecting side bundles and builds where steal is bundled with main