### PR TITLE
make sure steal's amdcjsregex branch works with steal-tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "pdenodeify": "^0.1.0",
     "prettier": "^1.3.1",
     "pump": "^1.0.2",
-    "steal": "^1.5.8",
+    "steal": "git://github.com/stealjs/steal#amdcjsregex",
     "steal-bundler": "^0.3.0",
     "steal-parse-amd": "^1.0.0",
     "through2": "^2.0.0",


### PR DESCRIPTION
Do not merge.
Just checking travis CI using steal's amdcjsregex branch to make sure it works with steal-tools
For #563

Ref: stealjs/steal#1249 (comment)