### PR TITLE
Include main bundle in other entry point bundles manifest

### DIFF
--- a/lib/stream/write_bundle_manifest.js
+++ b/lib/stream/write_bundle_manifest.js
@@ -3,7 +3,6 @@ var fs = require("fs-extra");
 var through = require("through2");
 var denodeify = require("pdenodeify");
 var concat = require("lodash/concat");
-var isArray = require("lodash/isArray");
 var includes = require("lodash/includes");
 var isString = require("lodash/isString");
 var isJavaScriptBundle = require("../bundle/is_js_bundle");
@@ -36,7 +35,7 @@ function writeBundleManifest(data) {
 	var manifest = {};
 
 	var entryPointBundles = concat(
-		isArray(data.loader.main) ? data.loader.main : [data.loader.main],
+		data.mains,
 		data.loader.bundle
 	);
 
@@ -44,7 +43,8 @@ function writeBundleManifest(data) {
 		manifest[bundleName] = getSharedBundlesOf(
 			bundleName,
 			data.loader.baseURL,
-			data.bundles
+			data.bundles,
+			data.mains
 		);
 	});
 
@@ -87,15 +87,20 @@ function getWeightOf(bundle) {
  * @param {string} name - A bundle name
  * @param {string} baseUrl - The loader's baseURL
  * @param {Array} bundles - The bundles array created by the build process
+ * @param {Array} mains - The main entry point modules
  * @return {Object} Each key is a shared bundle relative path and the value
  *                  contains the `weight` and `type` of the bundle
  */
-function getSharedBundlesOf(name, baseUrl, bundles) {
+function getSharedBundlesOf(name, baseUrl, bundles, mains) {
 	var shared = {};
 	var normalize = require("normalize-path");
+	// this will ensure that we only add the main bundle if there is a single
+	// main; not a multi-main project.
+	var singleMain = mains.length === 1 && mains[0];
 
 	bundles.forEach(function(bundle) {
-		if (includes(bundle.bundles, name)) {
+		if (includes(bundle.bundles, name) ||
+			includes(bundle.bundles, singleMain)) {
 			var relative = normalize(
 				path.relative(
 					baseUrl.replace("file:", ""),

--- a/test/slim_build_test.js
+++ b/test/slim_build_test.js
@@ -182,6 +182,10 @@ describe("slim builds", function() {
 						}
 					},
 					baz: {
+						"dist/bundles/main.js": {
+							weight: 2,
+							type: "script"
+						},
 						"dist/bundles/baz.js": {
 							weight: 2,
 							type: "script"


### PR DESCRIPTION
Since bundles correspond (roughly) to routes, the main bundle is always
going to be loaded when any other particular bundle is also loaded. So
the main bundle should be listed under each bundle's manifest entry.

This fixes #810. This is not a perfect fix, because for multi-build
projects, the main bundles won't be listed (nor should they be). This is
because the relationship between routes and bundles is not one-to-one,
		so we can't do this correctly without route information. #770
		seeks to solve that, and will result in the bundleManifest code
		being reconsidered.