### PR TITLE
Remove check for Symbol support in test file

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -19,13 +19,7 @@ require("./slim_build_conditionals_test");
 
 // Integration tests
 require("./test_cli");
-
-// Node 0.10 doesn't support Symbols so the live-reload tests will
-// not pass on it.
-if(typeof Symbol !== "undefined") {
-	require("./test_live");
-}
-
+require("./test_live");
 require("./bundle_name_test");
 require("./dependencygraph_test");
 require("./bundle_test");


### PR DESCRIPTION
steal-tool does not support node 0.1x