### PR TITLE
Support AMD "module" import

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "through2": "^2.0.0",
     "tmp": "0.0.33",
     "traceur": "0.0.111",
-    "transpile": "^2.5.3",
+    "transpile": "^2.5.5",
     "uglify-es": "^3.0.26",
     "urix": "^0.1.0",
     "winston": "^2.2.0",
@@ -88,7 +88,7 @@
     "coverage": "istanbul cover _mocha -- test/test --timeout 600000",
     "coverage:upload": "istanbul cover _mocha --report lcovonly -- test/test --timeout 600000 && cat ./coverage/lcov.info | ./node_modules/coveralls-send/bin/coveralls.js",
     "test:slim-worker-single": "node test/slim/worker/single/build.js && testee test/slim/worker/single/worker.html --browsers firefox --reporter Spec",
-    "test:slim-worker-progressive":  "node test/slim/worker/progressive/build.js && testee test/slim/worker/progressive/worker.html --browsers firefox --reporter Spec",
+    "test:slim-worker-progressive": "node test/slim/worker/progressive/build.js && testee test/slim/worker/progressive/worker.html --browsers firefox --reporter Spec",
     "test:exports-worker": "node test/exports_worker/exports.js && testee test/exports_worker/worker.html --browsers firefox --reporter Spec"
   },
   "engines": {

--- a/test/slim/module/index.html
+++ b/test/slim/module/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title></title>
+</head>
+<body>
+	<script src="dist/bundles/main.js"></script>
+</body>
+</html>

--- a/test/slim/module/main.js
+++ b/test/slim/module/main.js
@@ -1,0 +1,3 @@
+define(["module"], function(module) {
+	window.moduleId = module.id;
+});

--- a/test/slim/module/stealconfig.js
+++ b/test/slim/module/stealconfig.js
@@ -1,0 +1,3 @@
+steal.config({
+	main: "main"
+});

--- a/test/slim_build_test.js
+++ b/test/slim_build_test.js
@@ -675,4 +675,27 @@ describe("slim builds", function() {
 				close();
 			});
 	});
+
+	it("supports 'module' imports in AMD modules", function() {
+		var base = path.join(__dirname, "slim", "module");
+		var config = { config: path.join(base, "stealconfig.js") };
+
+		return rmdir(path.join(base, "dist"))
+			.then(function() {
+				return optimize(config, { minify: false, quiet: true });
+			})
+			.then(function() {
+				return open(path.join("test", "slim", "module", "index.html"));
+			})
+			.then(function(args) {
+				return Promise.all([args.close, find(args.browser, "moduleId")]);
+			})
+			.then(function(data) {
+				var close = data[0];
+				var moduleId = data[1];
+
+				assert.equal(moduleId, "main", "should set module.id");
+				close();
+			});
+	});
 });


### PR DESCRIPTION
Testing that the transpile changes work fine with steal-tools and that module like:

```js
define(["module"], function(module) {
  doSomethingWith(module);
});
```
are handled correctly in optimized builds.

Closes #845
