### PR TITLE
Prevent removing development code in a dev bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea
 dist
 coverage
+package-lock.json
 test/myapp/production.js
 test/css_paths/bundles/
 node_modules
@@ -38,4 +39,4 @@ test/live_reload/out.js
 test/transform_export/out.js
 test/exports_basics/out.js
 test/circular/export/
-/test/serviceworker/service-worker.js
+test/serviceworker/service-worker.js

--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -32,7 +32,10 @@ module.exports = function(config, options) {
 		dest: isDestProvided ? options.dest : "",
 		buildStealConfig: {
 			env: "bundle-build"
-		}
+		},
+		// Never really want to remove development strings when using
+		// deps/dev bundles
+		removeDevelopmentCode: false
 	});
 
 	return new Promise(function(resolve, reject) {

--- a/test/dev_bundle_app/dev_bundle_main.html
+++ b/test/dev_bundle_app/dev_bundle_main.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title></title>
+</head>
+<body>
+	<script>
+		window.steal = {
+            map: {
+                "@dev": "dev-bundle"
+            }
+        };
+    </script>
+
+	<script src="../../node_modules/steal/steal.js" config="./package.json!npm"></script>
+</body>
+</html>

--- a/test/dev_bundle_app/main.js
+++ b/test/dev_bundle_app/main.js
@@ -1,0 +1,7 @@
+"format cjs";
+
+//!steal-remove-start
+var someCode = "it worked";
+//!steal-remove-end
+
+window.MODULE = typeof someCode !== "undefined" ? someCode : "it failed";

--- a/test/dev_bundle_app/package.json
+++ b/test/dev_bundle_app/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dev_bundle_app",
+  "main": "main.js",
+  "version": "1.0.0"
+}

--- a/test/dev_bundle_build_test.js
+++ b/test/dev_bundle_build_test.js
@@ -7,6 +7,7 @@ var testHelpers = require("./helpers");
 var devBundleBuild = require("../lib/build/bundle");
 
 var open = testHelpers.popen;
+var find = testHelpers.pfind;
 var readFile = denodeify(fs.readFile);
 var rmdir = denodeify(require("rimraf"));
 
@@ -204,5 +205,26 @@ describe("dev bundle build", function() {
 				return rmdir(devBundlePath);
 			});
 	});
-});
 
+	it("Does not remove development code", function() {
+		var config = {
+			config: path.join(__dirname, "dev_bundle_app", "package.json!npm")
+		};
+
+		var devBundlePath = path.join(__dirname, "dev_bundle_app", "dev-bundle.js");
+
+		return devBundleBuild(config, baseOptions)
+			.then(function() {
+				return readFile(devBundlePath);
+			})
+			.then(function(contents) {
+				var nodeName = "it worked";
+				var regexp = new RegExp(_.escapeRegExp(nodeName));
+
+				assert(regexp.test(contents), "bundle should dev code");
+			})
+			.then(function() {
+				return rmdir(devBundlePath);
+			});
+	});
+});


### PR DESCRIPTION
This prevents the remove of development code (such as that which is in
		steal-remove-start/end comments).

Fixes https://github.com/stealjs/steal/issues/1288