### PR TITLE
Do not minify development bundles by default

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -16,8 +16,8 @@ module.exports = function(config, options) {
 
 	var isDestProvided = !!options.dest;
 
-	// minification is on by default
-	options.minify = options.minify == null ? true : options.minify;
+	// minification is disabled by default
+	options.minify = options.minify == null ? false : options.minify;
 
 	try {
 		options = assignDefaultOptions(config, options);


### PR DESCRIPTION
- Turning off minification speeds up bundle creation
- Fixes an issue with incorrect module detection caused by
  minified dev bundles (steal-tools appends a module that
  preloads package.json files to prevent requests of the bundled
  modules, if the package.json files include glob patterns it will
  break Steal.js module detection, only happens when the bundle
  is minified)

Closes https://github.com/stealjs/steal/issues/1227