### PR TITLE
Handle errors from uncleaned disconnected connections

### DIFF
--- a/lib/create_websocket_server.js
+++ b/lib/create_websocket_server.js
@@ -9,7 +9,7 @@ module.exports = function(options) {
 		if (options.sslCert && options.sslKey) {
 			server = require("https").createServer({
 				cert: fs.readFileSync(options.sslCert),
-				key: fs.readFileSync(options.sslKey)	
+				key: fs.readFileSync(options.sslKey)
 			});
 		} else if (options.sslPfx) {
 			server = require("https").createServer({

--- a/lib/stream/live.js
+++ b/lib/stream/live.js
@@ -34,7 +34,7 @@ module.exports = function(config, options){
 		function isStaleConnection(ws, error) {
 			var rs = ws.readyState;
 			return error.errno === "ECONNRESET" &&
-			(rs !== WS_CONNECTING && rs !== WS_CONNECTING);
+			(rs !== WS_OPEN && rs !== WS_CONNECTING);
 		}
 
 		wss.on("connection", function(ws){
@@ -46,7 +46,7 @@ module.exports = function(config, options){
 				});
 			});
 
-			ws.on("error", function(){
+			ws.on("error", function(err){
 				if(!isStaleConnection(ws, err)) {
 					console.error("WebSocket error:", err);
 				}

--- a/lib/stream/live.js
+++ b/lib/stream/live.js
@@ -6,6 +6,9 @@ var defaults = require("lodash").defaults;
 var logging = require("../logger");
 var toPromise = require("./to_promise");
 
+var WS_CONNECTING = 0;
+var WS_OPEN = 1;
+
 module.exports = function(config, options){
 	if(!options) options = {};
 	defaults(options, { quiet: true });
@@ -28,6 +31,12 @@ module.exports = function(config, options){
 	createServer(options).then(function(wss){
 		var port = wss.options.server.address().port;
 
+		function isStaleConnection(ws, error) {
+			var rs = ws.readyState;
+			return error.errno === "ECONNRESET" &&
+			(rs !== WS_CONNECTING && rs !== WS_CONNECTING);
+		}
+
 		wss.on("connection", function(ws){
 			// Get the initial graph for this main,
 			// if it's not already part of the graph.
@@ -35,6 +44,12 @@ module.exports = function(config, options){
 				graphPromise.then(function(){
 					graphStream.write(moduleName);
 				});
+			});
+
+			ws.on("error", function(){
+				if(!isStaleConnection(ws, err)) {
+					console.error("WebSocket error:", err);
+				}
 			});
 		});
 


### PR DESCRIPTION
Chrome 63 no longer closes its websocket connection cleanly, which
causes an error on the socket in the server.

This makes sure that we handle the error. Fixes #912