### PR TITLE
Do not use a single normalizeMap for all bundles

### DIFF
--- a/lib/graph/make_graph.js
+++ b/lib/graph/make_graph.js
@@ -15,7 +15,7 @@ var formatMap = {
 
 var SystemRegistry = global.SystemRegistry = {};
 
-module.exports = function makeGraph(config, options) { 
+module.exports = function makeGraph(config, options) {
 	options = options || {};
 	winston.info('OPENING: ' + (config.main || config.config || config.configMain));
 	var oldGlobalSystem = global.System;
@@ -34,12 +34,13 @@ module.exports = function makeGraph(config, options) {
 		localSteal.System.config(options.localStealConfig);
 	}
 
+
 	// Extensions and plugins can mutate these objects so the slim loader
 	// is able to handle special cases, like runtime mapping of userland
 	// module identifiers (like: "~/state/state") to slim numeric ids.
-	localSteal.System.normalizeMap = options.normalizeMap || {};
 	localSteal.System.slimConfig = options.slimConfig || makeSlimConfig();
 
+	localSteal.System.normalizeMap = {};
 	localSteal.System.systemName = (localSteal.System.systemName||"")+"-local";
 
 	// This version of steal, and its System can be used to load

--- a/lib/graph/make_graph_with_bundles.js
+++ b/lib/graph/make_graph_with_bundles.js
@@ -161,7 +161,6 @@ var makeBundleGraph = module.exports = function makeBundleGraph(config, options)
 				// plugin/extension used by the bundle will set its configuration
 				// to a fresh object reference that's lost after the dependency
 				// graph is created.
-				copyIfSet(data.loader, options, "normalizeMap");
 				copyIfSet(data.loader, options, "slimConfig");
 
 				return mainsPromise


### PR DESCRIPTION
Closes #939 

Before, We made both `normalizeMap` and `slimConfig` be a unique object reference for all bundles, but `normalizeMap` is used during transpilation and having a single references causes some module to be transpiled incorrectly because they are inhering state from previous bundles.

This change might affect slim bundles using `steal-conditional` in different bundles (although I don't think it matters since `normalizeMap` would be used right away by transpile and there is no need to collect everything like `slimConfig` for example)

I'm going to open a new issue to write a test for the slim build and make sure it works, but this fixes the issue affecting the CanJS build.

cc: @matthewp 