### PR TITLE
Recover from initial errors in live-reload

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/lib/create_websocket_server.js
+++ b/lib/create_websocket_server.js
@@ -24,6 +24,7 @@ module.exports = function(options) {
 			wss.on("connection", function(){
 				console.error("Received client connection");
 			});
+			wss.server = server;
 			resolve(wss);
 		});
 

--- a/lib/graph/recycle.js
+++ b/lib/graph/recycle.js
@@ -24,7 +24,7 @@ module.exports = function(config, options){
 
 		makeBundleGraph(cfg, options).then(function(data){
 			var graph = data.graph;
-			var oldGraph = cachedData.graph;
+			var oldGraph = cachedData ? cachedData.graph : {};
 			for(var name in graph){
 				if(name !== moduleName && oldGraph[name]) {
 					graph[name].transforms = oldGraph[name].transforms;
@@ -56,15 +56,16 @@ module.exports = function(config, options){
 			next(null, data);
 		} else {
 			var moduleName = data;
+
 			// Reload happened before the graph was loaded.
-			if(!cachedData) {
+			if(false && !cachedData) {
 				next(null, {});
 				return;
 			}
 
 			// Get the old node and check to see if it has any new dependencies,
 			// if so just regenerate the entire graph.
-			var node = cachedData.graph[moduleName];
+			var node = cachedData && cachedData.graph[moduleName];
 			if(node) {
 				diff(node).then(function(result){
 					if(result.same) {

--- a/lib/loader/find_bundle.js
+++ b/lib/loader/find_bundle.js
@@ -1,4 +1,4 @@
-var glob = require("glob").sync;
+var glob = require("globby").sync;
 
 module.exports = findBundles;
 

--- a/lib/stream/live.js
+++ b/lib/stream/live.js
@@ -53,8 +53,13 @@ module.exports = function(config, options){
 			});
 		});
 
-		var watchStream = watch(graphStream);
-		watchStream.on("data", onChange);
+		watch(graphStream).on("data", onChange);
+
+		function onInitialError(err) {
+			graphStream.emit("error", err);
+		}
+
+		initialGraphStream.once("error", onInitialError);
 
 		function onChange(moduleNames) {
 			if(moduleNames.length) {
@@ -76,6 +81,8 @@ module.exports = function(config, options){
 		}
 
 		graphStream.once("data", function(){
+			initialGraphStream.removeListener("error", onInitialError);
+
 			console.error("Live-reload server listening on port", port);
 		});
 
@@ -85,6 +92,11 @@ module.exports = function(config, options){
 			} else {
 				console.error(err);
 			}
+		});
+
+		graphStream.on("end", function(){
+			wss.close();
+			wss.server.close();
 		});
 
 		initialGraphStream.write(config.main);

--- a/lib/stream/watch.js
+++ b/lib/stream/watch.js
@@ -1,6 +1,7 @@
 var chokidar = require("chokidar");
 var ReadableStream = require("stream").Readable;
 var isWindowsCI = require("is-appveyor");
+var globby = require("globby");
 
 var ignored = /node_modules/;
 
@@ -21,7 +22,7 @@ module.exports = function(graphStream){
 			return;
 		}
 
-		var nodes = allNodes[address];
+		var nodes = allNodes ? allNodes[address] : [];
 
 		var moduleNames = (nodes || []).map(function(node){
 			return node.load.name;
@@ -40,6 +41,21 @@ module.exports = function(graphStream){
 	watcher.on("all", changed);
 
 	graphStream.on("data", updateWatch);
+
+	function onGraphStreamError() {
+		globby(["**/*"], {gitignore: true})
+		.then(function(paths){
+			watcher.add(paths);
+			graphStream.emit("watch-added");
+		})
+		.catch(() => {});
+	}
+
+	graphStream.once("error", onGraphStreamError);
+
+	graphStream.once("data", function(){
+		graphStream.removeListener("error", onGraphStreamError);
+	});
 
 	graphStream.on("end", function(){
 		watcher.close();

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "find-line-column": "^0.5.2",
     "fs-extra": "~5.0.0",
     "glob": "^7.1.1",
+    "globby": "^8.0.1",
     "gzip-size": "4.0.0",
     "is-appveyor": "^1.0.0",
     "lodash": "^4.17.0",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -99,3 +99,16 @@ exports.pfind = function(browser, property) {
 		check();
 	});
 };
+
+exports.preventErrors = function(){
+	var messages = [];
+	var consoleError = console.error;
+	console.error = function(){
+		messages.push([].slice.call(arguments));
+	};
+
+	return function(){
+		console.error = consoleError;
+		return messages;
+	};
+};


### PR DESCRIPTION
This makes it so that we can recover when there is an error when
live-reload first starts. What it does it:

1. Sets up a watcher on the entire root folder, using gitignore to
prevent watching stuff like node_modules (which significantly degrades
		watcher performance).
2. After a file has changed, runs the full graph again. Assuming it
works, we are in the clear from hence forth.

Fixes #954