### PR TITLE
Correctly remove development code on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 environment:
   matrix:
   # node.js
-  - nodejs_version: "6.0.0"
+  - nodejs_version: "8.0.0"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/lib/build/clean.js
+++ b/lib/build/clean.js
@@ -15,7 +15,7 @@ function clean(original, options) {
 
 function makeTagRegEx(tag) {
 	return new RegExp(
-		"(\\s?)//!(\\s?)" + tag + "-start((.|\n)*?)//!(\\s?)" + tag + "-end",
+		"(\\s?)//!(\\s?)" + tag + "-start((.|\r?\n)*?)//!(\\s?)" + tag + "-end",
 		"gim"
 	);
 }

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -161,7 +161,7 @@ describe("multi build", function(){
 				assert(!hasGlobalLongVariable, "Minified source includes a global that was minified.");
 			});
 	});
-	
+
 	it("should allow minification to be turned off", function() {
 		var config = {
 			config: path.join(__dirname, "minify", "config.js"),


### PR DESCRIPTION
This fixes the removal of development code when running on Windows.
Closes #959