### PR TITLE
Prevent npm preload module to break dev bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ test/transform_export/out.js
 test/exports_basics/out.js
 test/circular/export/
 test/serviceworker/service-worker.js
+!test/dev_bundles_minify/node_modules

--- a/lib/bundle/add_npm_packages_node.js
+++ b/lib/bundle/add_npm_packages_node.js
@@ -1,3 +1,4 @@
+var prettier = require("prettier");
 
 /**
  * Adds node to bundle to preload npm packages for dev bundles
@@ -6,11 +7,8 @@
  * @param {{}} npmContext The context containing the npm packages loaded
  */
 module.exports = function(bundle, npmContext) {
-	var unshift = [].unshift;
-
-	unshift.apply(bundle.nodes, [
-		makeAddNpmPackagesNode(npmContext)
-	]);
+	var push = [].push;
+	push.apply(bundle.nodes, [makeAddNpmPackagesNode(npmContext)]);
 };
 
 function makeAddNpmPackagesNode(npmContext) {
@@ -23,11 +21,12 @@ function makeAddNpmPackagesNode(npmContext) {
 			metadata: {
 				format: "global"
 			},
-			source: [
-				"if (steal && typeof steal.addNpmPackages === 'function') {",
-				"steal.addNpmPackages(" + JSON.stringify(packages) + ");",
-				"}"
-			].join(" ")
+			source: prettier.format(
+				`if (steal && typeof steal.addNpmPackages === "function") {
+					steal.addNpmPackages(${JSON.stringify(packages)});
+				}`,
+				{ tabWidth: 4 }
+			)
 		}
 	};
 }

--- a/test/dev_bundle_build_test.js
+++ b/test/dev_bundle_build_test.js
@@ -344,4 +344,38 @@ describe("dev bundle build", function() {
 				return rmdir(devBundlePath);
 			});
 	});
+
+	it("minified dev bundles work", function(done) {
+		var dir = path.join(__dirname, "dev_bundles_minify");
+		var devBundlePath = path.join(dir, "dev-bundle.js");
+
+		var config = {
+			config: path.join(dir, "package.json!npm")
+		};
+
+		var options = assign({}, baseOptions, {
+			minify: true,
+			filter: "node_modules/**/*" // only bundle npm deps
+		});
+
+		var clean = function(err) {
+			rmdir(devBundlePath).then(function() {
+				done(err);
+			});
+		};
+		devBundleBuild(config, options)
+			.then(function() {
+				var exists = fs.existsSync(devBundlePath);
+				assert(exists, "dev bundle should be created");
+			})
+			.then(function() {
+				return open("test/dev_bundles_minify/dev.html");
+			})
+			.then(function(p) {
+				p.close();
+				p.browser.assert.element("h1");
+			})
+			.then(clean)
+			.catch(clean);
+	});
 });

--- a/test/dev_bundles_minify/dev.html
+++ b/test/dev_bundles_minify/dev.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<title>Minified development bundles</title>
+</head>
+<body>
+	<script src="../../node_modules/steal/steal-sans-promises.js"
+		base-url="."
+		config-main="package.json!npm"
+		deps-bundle="dev-bundle"
+	></script>
+</body>
+</html>

--- a/test/dev_bundles_minify/main.js
+++ b/test/dev_bundles_minify/main.js
@@ -1,0 +1,6 @@
+var dummy = require("dummy");
+dummy();
+
+var h1 = document.createElement("h1");
+h1.innerHTML = "worked!";
+document.body.appendChild(h1);

--- a/test/dev_bundles_minify/node_modules/dummy/main.js
+++ b/test/dev_bundles_minify/node_modules/dummy/main.js
@@ -1,0 +1,7 @@
+module.exports = function() {
+	// the line below causes the commentRegex in steal to match from the
+	// glob pattern in the package.json to this line, steal will "thing"
+	// the `define` keywork is inside a comment, and the CJS extension will
+	// flag the bundle incorrectly
+	window.bar = "*/"; 
+};

--- a/test/dev_bundles_minify/node_modules/dummy/package.json
+++ b/test/dev_bundles_minify/node_modules/dummy/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "dummy",
+	"main": "main.js",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "foo bar/*.js"
+  }
+}

--- a/test/dev_bundles_minify/package.json
+++ b/test/dev_bundles_minify/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "app",
+	"main": "main.js",
+	"version": "1.0.0",
+	"dependencies": {
+		"dummy": "1.0.0"
+	}
+}


### PR DESCRIPTION
Closes #947 

Part of the problem is that the module to preload the npm packages is added at the top of the bundle. So we run into situations like:

```js
{ foo: "/*" };define("foo", function() { var bar = "*/" });
```

then the amd extension can't see the "define" because the comments regex matches a bunch of the module definition:

<img width="1060" alt="screen shot 2018-05-26 at 11 05 36 am" src="https://user-images.githubusercontent.com/724877/40578678-2eac9ea2-60d5-11e8-8a70-a03198fe71f0.png">

The solution I came up with was to push the module with the package.jsons to the bottom of the bundle, that way the first thing the regex matches is the actual AMD modules.

Placing the preloader at the bottom shouldn't matter since it gets executed right away. 