### PR TITLE
Use local babelOptions when compiling

### DIFF
--- a/lib/graph/transpile.js
+++ b/lib/graph/transpile.js
@@ -64,6 +64,13 @@ var transpileNode = function(node, outputFormat, options, graph, loader){
 			opts.transpiler = loader.transpiler || "babel"; // Babel is the default in Steal 1.x
 			if(loader.babelOptions) {
 				opts.babelOptions = loader.babelOptions;
+				var npmPkg = node.load.metadata.npmPackage;
+				if(npmPkg) {
+					var pkgSteal = npmPkg.steal || npmPkg.system;
+					if(pkgSteal && pkgSteal.babelOptions) {
+						opts.babelOptions = pkgSteal.babelOptions;
+					}
+				}
 
 				opts.babelOptions.presets = processBabelPresets({
 					baseURL: loader.baseURL,

--- a/test/babel_child/main.js
+++ b/test/babel_child/main.js
@@ -1,0 +1,9 @@
+import Child from "child";
+
+class Search {
+	child = new Child();
+}
+
+export default Search;
+
+window.search = new Search();

--- a/test/babel_child/node_modules/child/main.js
+++ b/test/babel_child/node_modules/child/main.js
@@ -1,0 +1,13 @@
+
+function plug() {
+
+}
+
+@plug
+class Child {
+	constructor() {
+		this.value = "worked";
+	}
+}
+
+export default Child;

--- a/test/babel_child/node_modules/child/package.json
+++ b/test/babel_child/node_modules/child/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "child",
+  "version": "1.0.0",
+  "main": "main.js",
+  "steal": {
+    "babelOptions": {
+      "plugins": [
+        "transform-decorators-legacy"
+      ]
+    }
+  }
+}

--- a/test/babel_child/package.json
+++ b/test/babel_child/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "babel_child",
+  "main": "main.js",
+  "version": "1.0.0",
+  "dependencies": {
+    "child": "1.0.0"
+  },
+  "steal": {
+    "babelOptions": {
+      "plugins": [
+        "transform-class-properties"
+      ]
+    }
+  }
+}

--- a/test/babel_child/prod.html
+++ b/test/babel_child/prod.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>custom babel plugins test</title>
+</head>
+<body>
+	<script src="./dist/steal.production.js"></script>
+</body>
+</html>

--- a/test/babel_plugins_test.js
+++ b/test/babel_plugins_test.js
@@ -88,6 +88,31 @@ describe("build app using babel plugins", function() {
 				}, done);
 			});
 	});
+
+	it("child babelOptions do not override the parent project's", function(done){
+		var base = path.join(__dirname, "babel_child");
+
+		rmdir(path.join(base, "dist"))
+			.then(function() {
+				return multiBuild({
+					config: path.join(base, "package.json!npm")
+				}, {
+					minify: false,
+					quiet: true
+				});
+			})
+			.then(function() {
+				var page = path.join("test", "babel_child", "prod.html");
+
+				open(page, function(browser, close) {
+					find(browser, "search", function(search) {
+						var val = search.child.value;
+						assert.equal(val, "worked", "built without exploding");
+						done();
+					}, close);
+				}, done);
+			}, done);
+	});
 });
 
 function copyDependencies() {

--- a/test/test_live.js
+++ b/test/test_live.js
@@ -169,7 +169,7 @@ describe("live-reload", function(){
 					assert.equal(dep.load.metadata.includedDeps[0],
 								 "file:" + nestedPath);
 
-					fs.writeFile(nestedPath, "bar", "utf8");
+					fs.writeFile(nestedPath, "bar", "utf8", Function.prototype);
 				});
 			});
 		});


### PR DESCRIPTION
This prefers the local package's babelOptions when transpiling.
Preventing any child package's configuration from overriding the root
package. Closes #1006