### PR TITLE
Adds the +bundled-es export helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - 6.0
   - 8.0
-  - node
+  - 10.2.1
 before_script:
   - npm dedupe
 before_install:

--- a/doc/transform.md
+++ b/doc/transform.md
@@ -1,5 +1,5 @@
 @function steal-tools.transform transform
-@parent steal-tools.JS 
+@parent steal-tools.JS
 
 A function provided by [steal-tools.transformImport] that returns a transformed
 module or modules.
@@ -10,10 +10,10 @@ module or modules.
 
 @param {steal-tools.transform.options} [options]
 
-Options that configure how the files are compiled.  These options overwrite the 
+Options that configure how the files are compiled.  These options overwrite the
 `pluginifierOptions` argument passed to [steal-tools.transformImport].
 
-@return {steal-tools.source.object} An object containing a string `code` property and a `map` that is the source map if the `sourceMaps` option is set to `true`.
+@return {Promise.<steal-tools.source.object>} A promise for an object containing a string `code` property and a `map` that is the source map if the `sourceMaps` option is set to `true`.
 
 @body
 
@@ -21,7 +21,7 @@ Options that configure how the files are compiled.  These options overwrite the
 
 After getting `transform` from [steal-tools.transformImport] you can call it, like:
 
-    var result = transform("module/name/to/build", {
+    var promise = transform("module/name/to/build", {
       // specifies modules to ignore
       ignore: [
         // ignores this module, and all of its dependencies
@@ -29,40 +29,40 @@ After getting `transform` from [steal-tools.transformImport] you can call it, li
         // ignores modules with names matching this pattern
         /can\//
       ],
-      
+
       // Remove code between !steal-remove-start and !steal-remove-end.
       // true by default.
       removeDevelopmentCode: true,
-      
+
       // Transpile the code to either "amd", "steal", "cjs" or "global".
-      // "global", the default, allows the file to work without any 
+      // "global", the default, allows the file to work without any
       // module loader.
       format: "global",
-      
+
       // Minify the file using uglify.
       // `false` by default.
       minify: true,
-      
-      // Only write the module specified by `moduleName`, instead of its 
+
+      // Only write the module specified by `moduleName`, instead of its
       // dependencies. `false` by default.
       ignoreAllDependencies: false
-      
+
       // Map module names to their name on the global object. Useful for
-      // building "global" modules that depend on other scripts already in 
+      // building "global" modules that depend on other scripts already in
       // the page.
       exports: {"jquery": "jQuery"},
-      
+
       // Transpile to normalized dependency names.
       // `true` by default.
       useNormalizedDependencies: true
-      
+
       // Custom normalization behavior
       // By default, the normalized name is used.
       normalize: function(name, currentModule, address){
         return name;
       }
-      
+
     });
-    
-Most of these options are optional.  For more 
+
+Most of these options are optional.  For more
 information, read [steal-tools.transform.options transformOptions].

--- a/lib/build/export.js
+++ b/lib/build/export.js
@@ -114,33 +114,35 @@ module.exports = function(config, defaults, modules){
 			ignore: outputOptions.ignore || out.output.ignore
 		});
 
-		var result = transform(moduleNames, options);
-		var filePath;
+		return transform(moduleNames, options)
+		.then(function(result){
+			var filePath;
 
-		if (_.isUndefined(out.output.dest)) {
-			return Promise.reject(new Error(
-				"Attribute 'dest' is required\n" +
-				"Add 'dest' to the ExportOutput object.\n" +
-				"See http://stealjs.com/docs/steal-tools.export.output.html#dest for more details."
-			));
-		}
-		else if (_.isString(out.output.dest)) {
-			filePath = out.output.dest;
-		}
-		else if (_.isFunction(out.output.dest)) {
-			// pull out the load objects of the modules being written out
-            var loads = (_.isString(moduleNames) ?
-                transform.graph[moduleNames].load :
-                moduleNames.map(function(moduleName){
-                    return transform.graph[moduleName].load;
-                }));
+			if (_.isUndefined(out.output.dest)) {
+				return Promise.reject(new Error(
+					"Attribute 'dest' is required\n" +
+					"Add 'dest' to the ExportOutput object.\n" +
+					"See http://stealjs.com/docs/steal-tools.export.output.html#dest for more details."
+				));
+			}
+			else if (_.isString(out.output.dest)) {
+				filePath = out.output.dest;
+			}
+			else if (_.isFunction(out.output.dest)) {
+				// pull out the load objects of the modules being written out
+				var loads = (_.isString(moduleNames) ?
+					transform.graph[moduleNames].load :
+					moduleNames.map(function(moduleName){
+						return transform.graph[moduleName].load;
+					}));
 
-			filePath = out.output.dest(moduleNames,
-				modulesMap[moduleNames], loads, transform.loader);
-		}
+				filePath = out.output.dest(moduleNames,
+					modulesMap[moduleNames], loads, transform.loader);
+			}
 
-		winston.info("> " + filePath);
-		return writeFile(filePath, result, config);
+			winston.info("> " + filePath);
+			return writeFile(filePath, result, config);
+		});
 	};
 
 	var processOutput = function(transform, out) {

--- a/lib/build/helpers/bundled-es.js
+++ b/lib/build/helpers/bundled-es.js
@@ -1,0 +1,58 @@
+var baseHelper = require("./base");
+var globalJS = require("./global").js;
+var npmUtils = require("steal/ext/npm-utils");
+
+var bundledES = {
+	modules: globalJS.modules,
+	skipTranspile: function(){
+		return true;
+	},
+	dest: globalJS.dest,
+	useNormalizedDependencies: globalJS.useNormalizedDependencies,
+	concatFormat: function(){
+		return "es";
+	},
+	normalize: function(){
+		return function(depName, depLoad, curName, curLoad, loader){
+			if(!depLoad) {
+				return depName;
+			}
+			var name = depLoad.name;
+			var res;
+
+			var isNpmName = npmUtils.moduleName.isNpm(name);
+
+			if(!isNpmName) {
+				return name;
+			}
+
+			// Get the package name. We need this to denpm the name.
+			var defaultPackage = npmUtils.pkg.getDefault(loader);
+			var packageName = isNpmName ?
+				npmUtils.moduleName.parse(name).packageName :
+				npmUtils.pkg.name(defaultPackage);
+
+
+			// convert this to what would be the normalized name
+			name = npmUtils.moduleName.parse(depLoad.name, packageName)
+				.modulePath;
+
+			// If this is the package's main like `lodash/main` use `lodash`
+			// instead.
+			var pkg = loader.npm[packageName] || defaultPackage;
+			if(name === npmUtils.pkg.main(pkg)) {
+				res = packageName;
+			} else {
+				res = packageName + "/" + name;
+			}
+
+			return res;
+		};
+
+	},
+	ignore: function(){
+		return false;
+	}
+}
+
+module.exports = baseHelper.makeHelper(bundledES);

--- a/lib/build/helpers/helpers.js
+++ b/lib/build/helpers/helpers.js
@@ -5,5 +5,6 @@ module.exports = {
 	cjs: require("./cjs"),
 	"global-js": g.js,
 	"global-css": g.css,
-	standalone: require("./standalone")
+	standalone: require("./standalone"),
+	"bundled-es": require("./bundled-es")
 };

--- a/lib/build/transform.js
+++ b/lib/build/transform.js
@@ -49,10 +49,12 @@ var transformImport = function(config, transformOptions){
 				minify: false,
 				removeDevelopmentCode: true,
 				format: "global",
+				concatFormat: "amd",
 				noGlobalShim: false,
 				includeTraceurRuntime: true,
 				ignoreAllDependencies: false,
-				removeSourceNodes: true
+				removeSourceNodes: true,
+				skipTranspile: false
 			},transformOptions, options);
 			var configuration = data.configuration =
 				makeConfiguration(data.loader, data.buildLoader, options);
@@ -108,11 +110,13 @@ var transformImport = function(config, transformOptions){
 			// #### transpile
 			winston.debug('Transpiling...');
 			options.sourceMapPath = configuration.bundlesPath;
-			transpile(nodesInBundle,
-				options.format === "global" ? "amd" : options.format,
-				options.format === "global" ? _.assign(_.clone(options),{namedDefines: true})  : options,
-				data);
 
+			if(options.skipTranspile !== true) {
+				transpile(nodesInBundle,
+					options.format === "global" ? "amd" : options.format,
+					options.format === "global" ? _.assign(_.clone(options),{namedDefines: true})  : options,
+					data);
+			}
 
 			// #### minify
 			if(options.minify) {
@@ -138,12 +142,23 @@ var transformImport = function(config, transformOptions){
 			bundle.nodes.forEach(function(node) {
 				winston.debug("+ %s", node.load.name);
 			});
-			concatSource(bundle,"activeSource", options.format === "global");
-			if(options.sourceMaps) {
-				addSourceMapUrl(bundle);
-			}
 
-			return bundle.source;
+			return Promise.resolve()
+			.then(function(){
+				var concatOptions = {
+					excludePlugins: options.format === "global",
+					sourceProp: "activeSource",
+					format: options.concatFormat
+				};
+				return concatSource(bundle, concatOptions);
+			})
+			.then(function(){
+				if(options.sourceMaps) {
+					addSourceMapUrl(bundle);
+				}
+
+				return bundle.source;
+			});
 		};
 
 		// Set the graph on transform in case anyone needs to use it.

--- a/lib/build/transform.js
+++ b/lib/build/transform.js
@@ -93,7 +93,7 @@ var transformImport = function(config, transformOptions){
 			// If there's nothing in this bundle, just give them an empty
 			// source object.
 			if(nodesInBundle.length === 0) {
-				return {code: ""};
+				return Promise.resolve({code: ""});
 			}
 
 			// resets the active source to be worked from.

--- a/lib/build/transform.js
+++ b/lib/build/transform.js
@@ -9,6 +9,7 @@ var makeGraph = require("../graph/make_graph"),
 	hasES6 = require("../graph/has_es6"),
 	addTraceurRuntime = require("../bundle/add_traceur_runtime"),
 	addGlobalShim = require("../bundle/add_global_shim"),
+	addProcessShim = require("../bundle/add_process_shim"),
 	transpile = require('../graph/transpile'),
 	clean = require("../graph/clean"),
 	minify = require("../graph/minify"),
@@ -54,7 +55,7 @@ var transformImport = function(config, transformOptions){
 				includeTraceurRuntime: true,
 				ignoreAllDependencies: false,
 				removeSourceNodes: true,
-				skipTranspile: false
+				addProcessShim: false
 			},transformOptions, options);
 			var configuration = data.configuration =
 				makeConfiguration(data.loader, data.buildLoader, options);
@@ -111,12 +112,10 @@ var transformImport = function(config, transformOptions){
 			winston.debug('Transpiling...');
 			options.sourceMapPath = configuration.bundlesPath;
 
-			if(options.skipTranspile !== true) {
-				transpile(nodesInBundle,
-					options.format === "global" ? "amd" : options.format,
-					options.format === "global" ? _.assign(_.clone(options),{namedDefines: true})  : options,
-					data);
-			}
+			transpile(nodesInBundle,
+				options.format === "global" ? "amd" : options.format,
+				options.format === "global" ? _.assign(_.clone(options),{namedDefines: true})  : options,
+				data);
 
 			// #### minify
 			if(options.minify) {
@@ -137,6 +136,10 @@ var transformImport = function(config, transformOptions){
 			}
 			if(hasES6(nodesInBundle) && options.includeTraceurRuntime){
 				addTraceurRuntime(bundle);
+			}
+			// Add shim for `process`
+			if(options.addProcessShim) {
+				addProcessShim(bundle, options);
 			}
 			winston.debug('Output Modules:');
 			bundle.nodes.forEach(function(node) {

--- a/lib/bundle/add_process_shim.js
+++ b/lib/bundle/add_process_shim.js
@@ -1,0 +1,22 @@
+var makeNode = require("../node/make_node"),
+	minify = require("../graph/minify"),
+	prettier = require("prettier");
+
+module.exports = function(bundle, options){
+	var source = prettier.format(
+		`
+			if(typeof process === "undefined") {
+				process = { env: { NODE_ENV: "development" } };
+			}
+		`,
+		{ useTabs: true }
+	);
+
+	var node = makeNode("[process-shim]", source);
+
+	if(options.minify){
+		minify([node]);
+	}
+
+	bundle.nodes.unshift(node);
+};

--- a/lib/bundle/concat_source.js
+++ b/lib/bundle/concat_source.js
@@ -1,73 +1,19 @@
-var path = require("path");
-var concat = require("../source-map-concat");
-var sourceNode = require("../node/source").node;
-var removeSourceMapUrl = require("../remove_source_map_url");
+var concatAMD = require("./concat_source_amd");
+var concatES = require("./concat_source_es");
 
-module.exports = function(bundle, sourceProp, excludePlugins){
-	var output = fileName(bundle);
+module.exports = function(bundle, options = {}){
+	var sourceProp = options.sourceProp;
+	var excludePlugins = options.excludePlugins;
 
-	var makeCode = function(name) {
-		return "define('" + name + "', [], function(){ return {}; });";
-	};
-
-	var nodes = bundle.nodes.map(function(node){
-		if (node.load.metadata &&
-			node.load.metadata.hasOwnProperty('bundle') &&
-			node.load.metadata.bundle === false) {
-
-			return { node: node, code: "", map: "" };
-		}
-
-		// Allow some nodes to be completely excluded
-		if(node.load.excludeFromBuild) {
-			return undefined;
-		}
-
-		// for plugins, include them only if they define `includeInBuild`
-		// or if the module's metadata has `includeInBuild` set to `true`
-		if (node.isPlugin &&
-			!node.value.includeInBuild &&
-			!node.load.metadata.includeInBuild) {
-
-			var code = excludePlugins ? "" : makeCode(node.load.name);
-			return { node: node, code: code };
-		}
-
-		var source = sourceNode(node, sourceProp);
-
-		return {
-			node: node,
-			code: removeSourceMapUrl((source.code || "") + ""),
-			map: source.map
-		};
-	}).filter(truthy);
-
-	var concatenated = concat(nodes, {
-		mapPath: output + ".map",
-		delimiter: "\n",
-		process: prependName
-	});
-
-	var result = concatenated.toStringWithSourceMap({
-		file: path.basename(output)
-	});
-
-	bundle.source = result;
-
-	function prependName(node, file) {
-		var load = file.node.load;
-		var prepend = node.prependModuleName !== false && load.name &&
-			load.metadata.prependModuleName !== false;
-
-		if(prepend) {
-			node.prepend("/*"+file.node.load.name+"*/\n");
-		}
+	var result;
+	
+	if(options.format === "es") {
+		result = concatES(bundle, sourceProp, excludePlugins);
+	} else if(options.format === "amd") {
+		result = concatAMD(bundle, sourceProp, excludePlugins);
+	} else {
+		return Promise.reject(new Error(`Unsupported concat format: ${options.format}`));
 	}
+
+	return Promise.resolve(result);
 };
-
-function fileName(bundle) {
-	var name = bundle.name || bundle.bundles[0] || bundle.nodes[0].load.name;
-	return name .replace("bundles/", "").replace(/\..+!/, "") + "." + bundle.buildType;
-}
-
-function truthy(x) { return !!x; }

--- a/lib/bundle/concat_source_amd.js
+++ b/lib/bundle/concat_source_amd.js
@@ -1,0 +1,73 @@
+var path = require("path");
+var concat = require("../source-map-concat");
+var sourceNode = require("../node/source").node;
+var removeSourceMapUrl = require("../remove_source_map_url");
+
+module.exports = function(bundle, sourceProp, excludePlugins){
+	var output = fileName(bundle);
+
+	var makeCode = function(name) {
+		return "define('" + name + "', [], function(){ return {}; });";
+	};
+
+	var nodes = bundle.nodes.map(function(node){
+		if (node.load.metadata &&
+			node.load.metadata.hasOwnProperty('bundle') &&
+			node.load.metadata.bundle === false) {
+
+			return { node: node, code: "", map: "" };
+		}
+
+		// Allow some nodes to be completely excluded
+		if(node.load.excludeFromBuild) {
+			return undefined;
+		}
+
+		// for plugins, include them only if they define `includeInBuild`
+		// or if the module's metadata has `includeInBuild` set to `true`
+		if (node.isPlugin &&
+			!node.value.includeInBuild &&
+			!node.load.metadata.includeInBuild) {
+
+			var code = excludePlugins ? "" : makeCode(node.load.name);
+			return { node: node, code: code };
+		}
+
+		var source = sourceNode(node, sourceProp);
+
+		return {
+			node: node,
+			code: removeSourceMapUrl((source.code || "") + ""),
+			map: source.map
+		};
+	}).filter(truthy);
+
+	var concatenated = concat(nodes, {
+		mapPath: output + ".map",
+		delimiter: "\n",
+		process: prependName
+	});
+
+	var result = concatenated.toStringWithSourceMap({
+		file: path.basename(output)
+	});
+
+	bundle.source = result;
+
+	function prependName(node, file) {
+		var load = file.node.load;
+		var prepend = node.prependModuleName !== false && load.name &&
+			load.metadata.prependModuleName !== false;
+
+		if(prepend) {
+			node.prepend("/*"+file.node.load.name+"*/\n");
+		}
+	}
+};
+
+function fileName(bundle) {
+	var name = bundle.name || bundle.bundles[0] || bundle.nodes[0].load.name;
+	return name .replace("bundles/", "").replace(/\..+!/, "") + "." + bundle.buildType;
+}
+
+function truthy(x) { return !!x; }

--- a/lib/bundle/concat_source_es.js
+++ b/lib/bundle/concat_source_es.js
@@ -4,7 +4,6 @@ var rollup = require("steal-rollup");
 var sourceNode = require("../node/source").node;
 
 const moduleNameFromSpecifier = dependencyResolver.moduleNameFromSpecifier;
-const moduleSpecifierFromName = dependencyResolver.moduleSpecifierFromName;
 const CJS_PROXY_PREFIX = '\0commonjs-proxy:';
 
 module.exports = function(bundle, sourceProp, excludePlugins){
@@ -57,5 +56,5 @@ function loadFromGraph(getNode, sourceProp) {
 
 			return source;
 		}
-	}
+	};
 }

--- a/lib/bundle/concat_source_es.js
+++ b/lib/bundle/concat_source_es.js
@@ -1,0 +1,61 @@
+var dependencyResolver = require("../node/dependency_resolver");
+var pluginCommonjs = require("rollup-plugin-commonjs");
+var rollup = require("steal-rollup");
+var sourceNode = require("../node/source").node;
+
+const moduleNameFromSpecifier = dependencyResolver.moduleNameFromSpecifier;
+const moduleSpecifierFromName = dependencyResolver.moduleSpecifierFromName;
+const CJS_PROXY_PREFIX = '\0commonjs-proxy:';
+
+module.exports = function(bundle, sourceProp, excludePlugins){
+	let main = bundle.bundles[0];
+
+	let nodeMap = new Map();
+	for(let node of bundle.nodes) {
+		nodeMap.set(node.load.name + ".js", node);
+	}
+	let getNode = nodeMap.get.bind(nodeMap);
+
+	return rollup.rollup({
+		input: main,
+
+		plugins: [
+			loadFromGraph(getNode, sourceProp, excludePlugins),
+			pluginCommonjs({})
+		]
+	})
+	.then(function(bundle){
+		return bundle.generate({
+			format:'es',
+			sourcemap: true
+		});
+	})
+	.then(function(chunk){
+		bundle.source = {
+			code: chunk.code,
+			map: chunk.map
+		};
+	});
+};
+
+function loadFromGraph(getNode, sourceProp) {
+	return {
+		resolveId: function(id, importer) {
+			if(id.startsWith(CJS_PROXY_PREFIX)) {
+				id = id.substr(CJS_PROXY_PREFIX.length);
+			}
+			if(importer) {
+				let node = getNode(importer);
+				var outId = moduleNameFromSpecifier(node, id);
+				return (outId === "@empty" ? id : outId) + ".js";
+			}
+			return id + ".js";
+		},
+		load(id) {
+			let node = getNode(id);
+			let source = sourceNode(node, sourceProp);
+
+			return source;
+		}
+	}
+}

--- a/lib/bundle/concat_source_es.js
+++ b/lib/bundle/concat_source_es.js
@@ -1,13 +1,14 @@
-var dependencyResolver = require("../node/dependency_resolver");
-var pluginCommonjs = require("rollup-plugin-commonjs");
-var rollup = require("steal-rollup");
-var sourceNode = require("../node/source").node;
+const dependencyResolver = require("../node/dependency_resolver");
+const isProcessShim = require("../node/is_process_shim");
+const pluginCommonjs = require("rollup-plugin-commonjs");
+const rollup = require("steal-rollup");
 
 const moduleNameFromSpecifier = dependencyResolver.moduleNameFromSpecifier;
 const CJS_PROXY_PREFIX = '\0commonjs-proxy:';
 
-module.exports = function(bundle, sourceProp, excludePlugins){
+module.exports = function(bundle) {
 	let main = bundle.bundles[0];
+	let firstNode = bundle.nodes[0];
 
 	let nodeMap = new Map();
 	for(let node of bundle.nodes) {
@@ -19,7 +20,7 @@ module.exports = function(bundle, sourceProp, excludePlugins){
 		input: main,
 
 		plugins: [
-			loadFromGraph(getNode, sourceProp, excludePlugins),
+			loadFromGraph(getNode),
 			pluginCommonjs({})
 		]
 	})
@@ -30,14 +31,19 @@ module.exports = function(bundle, sourceProp, excludePlugins){
 		});
 	})
 	.then(function(chunk){
+		let sourceCode = chunk.code;
+		if(isProcessShim(firstNode)) {
+			sourceCode = firstNode.load.source + "\n" + sourceCode;
+		}
+
 		bundle.source = {
-			code: chunk.code,
+			code: sourceCode,
 			map: chunk.map
 		};
 	});
 };
 
-function loadFromGraph(getNode, sourceProp) {
+function loadFromGraph(getNode) {
 	return {
 		resolveId: function(id, importer) {
 			if(id.startsWith(CJS_PROXY_PREFIX)) {
@@ -46,14 +52,23 @@ function loadFromGraph(getNode, sourceProp) {
 			if(importer) {
 				let node = getNode(importer);
 				var outId = moduleNameFromSpecifier(node, id);
+				// Likely one of the commonjs plugins' weird internal modules
+				if(!outId) {
+					return undefined;
+				}
 				return (outId === "@empty" ? id : outId) + ".js";
 			}
 			return id + ".js";
 		},
 		load(id) {
 			let node = getNode(id);
-			let source = sourceNode(node, sourceProp);
 
+			// Likely one of the commonjs plugins' weird internal modules
+			if(!node) {
+				return undefined;
+			}
+
+			let source = node.load.source;
 			return source;
 		}
 	};

--- a/lib/bundle/concat_stream.js
+++ b/lib/bundle/concat_stream.js
@@ -43,5 +43,5 @@ function concat(data) {
 		promises.push(concatSource(bundle, { format: "amd" }));
 	});
 
-	return Promise.all(promises).then(_ => data);
+	return Promise.all(promises).then(() => data);
 }

--- a/lib/bundle/concat_stream.js
+++ b/lib/bundle/concat_stream.js
@@ -7,8 +7,10 @@ var normalizeSource = require("./normalize_source");
 module.exports = function(){
 	return through.obj(function(data, enc, next) {
 		try {
-			var result = concat(data);
-			next(null, result);
+			var p = concat(data);
+			p.then(function(result){
+				next(null, result);
+			});
 		} catch(err) {
 			next(err);
 		}
@@ -23,6 +25,8 @@ function concat(data) {
 	var bundlesDir = _.endsWith(bundlesPath, "/") ?
 		bundlesPath : bundlesPath + "/";
 
+	var promises = [];
+
 	bundles.forEach(function(bundle){
 		var bundlePath = bundle.bundlePath =
 			bundlesDir + "" + bundleFilename(bundle);
@@ -36,8 +40,8 @@ function concat(data) {
 		normalizeSource(bundle, bundlePath);
 
 		// Combines the source
-		concatSource(bundle);
+		promises.push(concatSource(bundle, { format: "amd" }));
 	});
 
-	return data;
+	return Promise.all(promises).then(_ => data);
 }

--- a/lib/cli/cmd_transform.js
+++ b/lib/cli/cmd_transform.js
@@ -34,10 +34,10 @@ module.exports = {
 
 		return stealTools.transform(config, options)
 			.then(function(transform){
-				var result = transform(null, {
+				return transform(null, {
 					ignore: ignore
 				});
-
+			}).then(function(result){
 				var code = result.code;
 				var map = result.map;
 

--- a/lib/node/is_process_shim.js
+++ b/lib/node/is_process_shim.js
@@ -1,0 +1,4 @@
+
+module.exports = function(node) {
+	return node.load.name === "[process-shim]";
+};

--- a/lib/node/make_node.js
+++ b/lib/node/make_node.js
@@ -3,7 +3,11 @@ var nodeSource = require("./source");
 module.exports = function(name, source, type){
 	return {
 		load: {
-			metadata: {format: type || "global"},
+			metadata: {
+				format: type || "global",
+				dependencies: [],
+				deps: []
+			},
 			source: source || "",
 			name: name
 		},

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "pdenodeify": "^0.1.0",
     "prettier": "1.12.0",
     "pump": "^3.0.0",
+    "rollup-plugin-commonjs": "^9.1.3",
     "steal": "^2.0.0-pre.7",
     "steal-bundler": "^0.3.6",
     "steal-parse-amd": "^1.0.0",

--- a/test/export_bundled_es_test.js
+++ b/test/export_bundled_es_test.js
@@ -1,0 +1,30 @@
+var assert = require("assert");
+var stealExport = require("../lib/build/export");
+var rmdir = require("rimraf");
+var testHelpers = require("./helpers");
+
+var find = testHelpers.find;
+var open = testHelpers.open;
+
+
+describe("+bundled-es", function(){
+	it("Works with a basic app with npm dependencies", function(done){
+		this.timeout(10000);
+		stealExport({
+			steal: {
+				config: __dirname+"/exports_basics/package.json!npm",
+				main: "app/index_es"
+			},
+			options: { quiet: true },
+			"outputs": {
+				"+bundled-es": {
+					dest: __dirname + "/exports_basics/dist/es.js"
+				}
+			}
+		})
+		.then(function() {
+			assert.ok(true, "it built");
+			done();
+		}, done);
+	});
+});

--- a/test/export_bundled_es_test.js
+++ b/test/export_bundled_es_test.js
@@ -27,4 +27,28 @@ describe("+bundled-es", function(){
 			done();
 		}, done);
 	});
+
+	it("Works when also doing a global build", function(done){
+		this.timeout(10000);
+		stealExport({
+			steal: {
+				config: __dirname+"/exports_basics/package.json!npm",
+				main: "app/index_es"
+			},
+			options: { quiet: true },
+			"outputs": {
+				"+standalone": {
+					dest: __dirname + "/exports_basics/dist/global.js"
+				},
+				"+bundled-es": {
+					addProcessShim: true,
+					dest: __dirname + "/exports_basics/dist/es.js"
+				}
+			}
+		})
+		.then(function() {
+			assert.ok(true, "it built");
+			done();
+		}, done);
+	})
 });

--- a/test/export_global_css_test.js
+++ b/test/export_global_css_test.js
@@ -34,7 +34,8 @@ describe("+global-css", function(){
 						close();
 					}, close);
 				}, done);
-			});
+			})
+			.catch(done);
 		});
 	});
 });

--- a/test/export_test.js
+++ b/test/export_test.js
@@ -102,9 +102,13 @@ describe("export", function(){
 		}, done);
 	});
 
-	it("passes the load objects to normalize and dest", function(done){
-		var destCalls = 0;
+	process.on('unhandledRejection', function(){
+		debugger;
+	})
 
+	it("passes the load objects to normalize and dest", function(done){
+		var ignoreCalls = 0;
+		var destCalls = 0;
 		stealExport({
 
 			steal: {
@@ -128,11 +132,11 @@ describe("export", function(){
 						return name;
 					},
 					ignore: function(moduleName, load){
-						switch(destCalls++) {
+						switch(ignoreCalls++) {
 							case 0:
 								assert.equal(load.name, "pluginifier_builder_load/main");
 								break;
-							case 2:
+							case 1:
 								assert.equal(load.name, "pluginifier_builder_load/bar");
 								return true;
 								break;
@@ -143,7 +147,7 @@ describe("export", function(){
 					},
 					dest: function(moduleName, moduleData, load){
 						switch(destCalls++) {
-							case 1:
+							case 0:
 								assert.equal(load.name, "pluginifier_builder_load/main");
 								break;
 							default:
@@ -155,18 +159,15 @@ describe("export", function(){
 					minify: false
 				}
 			}
-		}).then(function(err){
-
-			done();
-
-		}, done);
+		}).then(() => done())
+		.catch(done);
 	});
 
 	it("passes the load objects to normalize and dest (+cjs)", function(done) {
+		var ignoreCalls = 0;
 		var destCalls = 0;
 
 		stealExport({
-
 			steal: {
 				main: "pluginifier_builder_load/main",
 				config: __dirname + "/stealconfig.js"
@@ -188,11 +189,11 @@ describe("export", function(){
 						return name;
 					},
 					ignore: function(moduleName, load){
-						switch(destCalls++) {
+						switch(ignoreCalls++) {
 							case 0:
 								assert.equal(load.name, "pluginifier_builder_load/main");
 								break;
-							case 2:
+							case 1:
 								assert.equal(load.name, "pluginifier_builder_load/bar");
 								return true;
 								break;
@@ -203,7 +204,7 @@ describe("export", function(){
 					},
 					dest: function(moduleName, moduleData, load){
 						switch(destCalls++) {
-							case 1:
+							case 0:
 								assert.equal(load.name, "pluginifier_builder_load/main");
 								break;
 							default:
@@ -215,11 +216,9 @@ describe("export", function(){
 					minify: false
 				}
 			}
-		}).then(function(err){
-
-			done();
-
-		}, done);
+		})
+		.then(() => done())
+		.catch(done);
 	});
 
 	it("evaled globals do not have exports in their scope (#440)", function(done){

--- a/test/exports_basics/index_es.js
+++ b/test/exports_basics/index_es.js
@@ -1,0 +1,8 @@
+import foo from "foo";
+
+let name = "index";
+
+export {
+	name,
+	foo
+};

--- a/test/test.js
+++ b/test/test.js
@@ -33,6 +33,7 @@ require("./export_test");
 require("./export_global_js_test");
 require("./export_global_css_test");
 require("./export_standalone_test");
+require("./export_bundled_es_test");
 require("./continuous_test");
 require("./concat_test");
 require("./graph_stream_test");

--- a/test/tree_shaking_test.js
+++ b/test/tree_shaking_test.js
@@ -50,7 +50,10 @@ describe("Tree-shaking", function(){
 							done();
 						});
 				})
-				.catch(done);
+				.catch(err => {
+					console.error(err);
+					done(err);
+				});
 		}
 	}
 


### PR DESCRIPTION
This adds a +bundled-es export helper that will create a bundle of ES
modules.

Example usage:

```js
stealExport({
	steal: {
		config: __dirname+"/package.json!npm"
	},
	options: {},
	"outputs": {
		"+bundled-es": {
			dest: __dirname + "/dist/library.mjs"
		}
	}
})
```