### PR TITLE
Makes process available for the global shim

### DIFF
--- a/lib/build/transform.js
+++ b/lib/build/transform.js
@@ -9,6 +9,7 @@ var makeGraph = require("../graph/make_graph"),
 	hasES6 = require("../graph/has_es6"),
 	addTraceurRuntime = require("../bundle/add_traceur_runtime"),
 	addGlobalShim = require("../bundle/add_global_shim"),
+	addProcessShim = require("../bundle/add_process_shim"),
 	transpile = require('../graph/transpile'),
 	clean = require("../graph/clean"),
 	minify = require("../graph/minify"),
@@ -130,6 +131,9 @@ var transformImport = function(config, transformOptions){
 			// add shim if global
 			if(options.format === "global" && !options.noGlobalShim) {
 				addGlobalShim(bundle, options);
+			}
+			if(options.format === "global" && !options.noProcessShim) {
+				addProcessShim(bundle, options);
 			}
 			if(hasES6(nodesInBundle) && options.includeTraceurRuntime){
 				addTraceurRuntime(bundle);

--- a/lib/bundle/add_process_shim.js
+++ b/lib/bundle/add_process_shim.js
@@ -1,0 +1,30 @@
+
+var makeNode = require("../node/make_node"),
+	minify = require("../graph/minify"),
+	fs = require("fs"),
+	path = require("path"),
+	prettier = require("prettier");
+
+// makes it so this bundle loads steal
+module.exports = function(bundle, options){
+	var processFn = fs.readFileSync(path.join(__dirname, "shim-process.js"));
+    var env = options.env || "development";
+
+	// target global variable, self (Web Workers) or window
+	var g = `typeof self == "object" && self.Object == Object ? self : (typeof process === "object" && Object.prototype.toString.call(process) === "[object process]") ? global : window`;
+
+	var source = prettier.format(
+		`(${processFn.toString()})(
+			${g},
+			${JSON.stringify(env)}
+		);`,
+		{ useTabs: true }
+	);
+
+	var start = makeNode("[process-shim]", source);
+
+	if(options.minify){
+		minify([start]);
+	}
+	bundle.nodes.unshift(start);
+};

--- a/lib/bundle/shim-process.js
+++ b/lib/bundle/shim-process.js
@@ -10,7 +10,7 @@ function(global, env){ // jshint ignore:line
     			NODE_ENV: env || "development"
     		},
     		version: '',
-    		platform: (typeof navigator !== "undefined" && navigator.userAgent && /Windows/.test(navigator.userAgent)) ? "win" : ""
+    		platform: (global.navigator && global.navigator.userAgent && /Windows/.test(global.navigator.userAgent)) ? "win" : ""
     	};
     }
 }

--- a/lib/bundle/shim-process.js
+++ b/lib/bundle/shim-process.js
@@ -1,0 +1,16 @@
+function(global, env){ // jshint ignore:line
+    if(typeof process === "undefined") {
+        global.process = {
+    		argv: [],
+    		cwd: function(){
+    			return "";
+    		},
+    		browser: true,
+    		env: {
+    			NODE_ENV: env || "development"
+    		},
+    		version: '',
+    		platform: (typeof navigator !== "undefined" && navigator.userAgent && /Windows/.test(navigator.userAgent)) ? "win" : ""
+    	};
+    }
+}

--- a/test/export_standalone_test.js
+++ b/test/export_standalone_test.js
@@ -63,19 +63,21 @@ describe("+standalone", function(){
 		});
 	});
 
-	it("Can be used for node.js projects", function(done){
+	it("Can be used for node.js projects with process and defaults to not prod", function(done){
 		this.timeout(10000);
 
 		var outPath = __dirname + "/exports_basics/out.js";
 
 		stealExport({
 			steal: {
+				main: "app/uses-process",
 				config: __dirname + "/exports_basics/package.json!npm"
 			},
 			options: { quiet: true },
 			outputs: {
 				"+standalone": {
-					exports: { "foo": "FOO.foo" },
+					modules: ["app/uses-process"],
+					exports: { "app/uses-process": "EXP_PROCESS" },
 					dest: function(){
 						return outPath;
 					}
@@ -83,9 +85,49 @@ describe("+standalone", function(){
 			}
 		})
 		.then(function(){
-			require(outPath);
-			assert.ok(true, "Was able to require the created module");
-			done();
+			open("test/exports_basics/global.html",
+				 function(browser, close) {
+				find(browser,"EXP_PROCESS", function(expProcess){
+					assert.equal(expProcess.env, "NOT-PROD", "not in prod by default");
+					close();
+				}, close);
+			}, done);
+		})
+		.catch(done);
+
+	});
+
+	it.only("Can be used for node.js projects with process and can be set to production", function(done){
+		this.timeout(10000);
+
+		var outPath = __dirname + "/exports_basics/out.js";
+
+		stealExport({
+			steal: {
+				main: "app/uses-process",
+				config: __dirname + "/exports_basics/package.json!npm"
+			},
+			options: { quiet: true },
+			outputs: {
+				"+standalone": {
+					modules: ["app/uses-process"],
+					exports: { "app/uses-process": "EXP_PROCESS" },
+					dest: function(){
+						return outPath;
+					},
+					// sets to production
+					env: "production"
+				}
+			}
+		})
+		.then(function(){
+			open("test/exports_basics/global.html",
+				 function(browser, close) {
+				find(browser,"EXP_PROCESS", function(expProcess){
+					assert.equal(expProcess.env, "PROD", "not in prod by default");
+					close();
+				}, close);
+			}, done);
 		})
 		.catch(done);
 

--- a/test/exports_basics/uses-process.html
+++ b/test/exports_basics/uses-process.html
@@ -1,0 +1,1 @@
+<script src="out.js"></script>

--- a/test/exports_basics/uses-process.js
+++ b/test/exports_basics/uses-process.js
@@ -1,0 +1,8 @@
+var value;
+if (process.env.NODE_ENV !== 'production') {
+    value = {env: "NOT-PROD"};
+} else {
+    value = {env: "PROD"};
+}
+
+module.exports = value;


### PR DESCRIPTION
For #1024 

This adds a `bundle/add_process_shim` that adds a `process` object similar to the one steal's `npm` package does.  This shim is added by default, unless `noProcessShim` is `true` (similar to `noGlobalShim`).

Furthermore, `add_process_shim` will use `options.env` as the `env.NODE_ENV`.  This defaults to `"development"`.

There are tests for both the default development and `env: "production"` cases.  


problems / considerations:

1.  This duplicates the `global` identifying code.  I'm not sure how we could avoid this.
2.  The steal `process` shim's `cwd` defaults to `steal.baseUrl`.  I defaulted it to `""`.  
3.  Steal 2.0 will need to merge and release this.
4.  There's no documentation around `noProcessShim` and `env`.
5. There's not a test for `noGlobalShim`.