### PR TITLE
Prevent client-side tree shaking of dev bundles

### DIFF
--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -21,7 +21,7 @@ module.exports = function(cfg, options) {
 	options.minify = options.minify == null ? false : options.minify;
 
 	// tree shaking is disabled.
-	var config  = { treeShaking: false, ...cfg };
+	var config = Object.assign({ treeShaking: false }, cfg);
 
 	try {
 		options = assignDefaultOptions(config, options);

--- a/lib/build/bundle.js
+++ b/lib/build/bundle.js
@@ -11,7 +11,7 @@ var createWriteStream = require("../bundle/write_bundles").createWriteStream;
 var createBundleGraphStream = require("../graph/make_graph_with_bundles")
 	.createBundleGraphStream;
 
-module.exports = function(config, options) {
+module.exports = function(cfg, options) {
 	// Use the build-development environment.
 	if (!options) options = {};
 
@@ -19,6 +19,9 @@ module.exports = function(config, options) {
 
 	// minification is disabled by default
 	options.minify = options.minify == null ? false : options.minify;
+
+	// tree shaking is disabled.
+	var config  = { treeShaking: false, ...cfg };
 
 	try {
 		options = assignDefaultOptions(config, options);

--- a/test/dev_bundle_build_test.js
+++ b/test/dev_bundle_build_test.js
@@ -412,4 +412,41 @@ describe("dev bundle build", function() {
 			.then(clean)
 			.catch(clean);
 	});
+
+	it("Doesn't tree shake dependencies", function(done) {
+		var dir = path.join(__dirname, "treeshake", "basics");
+		var devBundlePath = path.join(dir, "dev-bundle.js");
+
+		var config = {
+			config: path.join(dir, "package.json!npm")
+		};
+
+		var options = assign({}, baseOptions, {
+			minify: false,
+			filter: ["node_modules/**/*", "package.json"] // only bundle npm deps
+		});
+
+		var clean = function(err) {
+			rmdir(devBundlePath).then(function() {
+				done(err);
+			});
+		};
+
+		devBundleBuild(config, options)
+			.then(function() {
+				return open("test/treeshake/basics/dev.html");
+			})
+			.then(function(p) {
+				return find(p.browser, "APP").then(function(){
+					return p.browser.window;
+				})
+			})
+			.then(function(window){
+				var steal = window.steal;
+				var canConnect = steal.loader.get("can-connect@1.0.0#main");
+				assert.ok(canConnect, "Not tree shaken");
+			})
+			.then(clean)
+			.catch(clean);
+	});
 });

--- a/test/treeshake/basics/dev.html
+++ b/test/treeshake/basics/dev.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="X-UA-Compatible" content="ie=edge">
+	<title>Development bundles and tree shaking</title>
+</head>
+<body>
+	<script
+		src="../../../node_modules/steal/steal.js"
+		base-url="."
+		config-main="package.json!npm"
+		dev-bundle
+		main
+	>
+		import app from "treeshake";
+
+		window.APP = { app };
+	</script>
+</body>
+</html>


### PR DESCRIPTION
This prevents the client-side tree shaking from occuring when dev
bundles are being built, since you always want that code included within
the bundle. Fixes #1044