### PR TITLE
Disable client-side treeshaking when BuildOption is used

### DIFF
--- a/lib/assign_default_options.js
+++ b/lib/assign_default_options.js
@@ -44,6 +44,11 @@ module.exports = function(config, options){
 		throw new Error("bundlesPath has been removed. Use dest instead: http://stealjs.com/docs/steal-tools.BuildOptions.html");
 	}
 
+	// Tree-shaking
+	if(options.treeShaking === false) {
+		config.treeShaking = false;
+	}
+
 	// package.json!npm is now the default
 	if(!config.config && !config.configMain) {
 		config.configMain = "package.json!npm";

--- a/test/tree_shaking_test.js
+++ b/test/tree_shaking_test.js
@@ -179,6 +179,51 @@ describe("Tree-shaking", function(){
 				assert.equal(typeof dep.two, "function", "Included");
 			});
 		});
+
+		describe("With a multi-main project", function(){
+			var app;
+			before(function(done){
+				this.timeout(20000);
+				var base = path.join(__dirname, "treeshake", "multimain");
+				var config = {
+					config: path.join(base, "package.json!npm"),
+					main: [
+						"~/main1",
+						"~/main2"
+					]
+				};
+				var page = `prod1.html`;
+
+				rmdir(path.join(base, "dist"))
+					.then(function() {
+						return optimize(config, {
+							quiet: true,
+							minify: false,
+							treeShaking: false
+						});
+					})
+					.then(function() {
+						var close;
+						return open(path.join("test", "treeshake", "multimain", page))
+							.then(function(args) {
+								close = args.close;
+								browser = args.browser;
+								return find(browser, "globals");
+							})
+							.then(function(mod) {
+								app = mod;
+								close();
+								done();
+							});
+					})
+					.catch(done);
+			});
+
+			it("Doesn\'t tree shake modules", function(){
+				let Component = app.Component;
+				assert.equal(typeof Component, "function", "was not tree-shaken");
+			});
+		});
 	});
 
 	describe("Bundles", function() {

--- a/test/treeshake/multimain/es/lib-ajax.js
+++ b/test/treeshake/multimain/es/lib-ajax.js
@@ -1,0 +1,1 @@
+export {default} from "./lib/ajax";

--- a/test/treeshake/multimain/es/lib-component.js
+++ b/test/treeshake/multimain/es/lib-component.js
@@ -1,0 +1,1 @@
+export {default} from "./lib/component";

--- a/test/treeshake/multimain/es/lib-map.js
+++ b/test/treeshake/multimain/es/lib-map.js
@@ -1,0 +1,1 @@
+export {default} from "./lib/map";

--- a/test/treeshake/multimain/es/lib/ajax.js
+++ b/test/treeshake/multimain/es/lib/ajax.js
@@ -1,0 +1,6 @@
+
+function ajax() {
+
+}
+
+module.exports = ajax;

--- a/test/treeshake/multimain/es/lib/component.js
+++ b/test/treeshake/multimain/es/lib/component.js
@@ -1,0 +1,6 @@
+
+class Component {
+
+}
+
+module.exports = Component;

--- a/test/treeshake/multimain/es/lib/map.js
+++ b/test/treeshake/multimain/es/lib/map.js
@@ -1,0 +1,6 @@
+
+class Map {
+
+}
+
+module.exports = Map;

--- a/test/treeshake/multimain/lib-core.js
+++ b/test/treeshake/multimain/lib-core.js
@@ -1,0 +1,2 @@
+export { default as Component } from "./es/lib-component";
+export { default as Map } from "./es/lib-map";

--- a/test/treeshake/multimain/lib-ecosystem.js
+++ b/test/treeshake/multimain/lib-ecosystem.js
@@ -1,0 +1,1 @@
+export { default as ajax } from "./es/lib-ajax";

--- a/test/treeshake/multimain/lib.js
+++ b/test/treeshake/multimain/lib.js
@@ -1,0 +1,2 @@
+export * from "./lib-core.js";
+export * from "./lib-ecosystem.js";

--- a/test/treeshake/multimain/main1.js
+++ b/test/treeshake/multimain/main1.js
@@ -1,0 +1,4 @@
+import { Component } from "./lib";
+
+window.globals = window.globals || {};
+window.globals.Component = Component;

--- a/test/treeshake/multimain/main2.js
+++ b/test/treeshake/multimain/main2.js
@@ -1,0 +1,4 @@
+import { Map } from "./lib";
+
+window.globals = window.globals || {};
+window.globals.Map = Map;

--- a/test/treeshake/multimain/package.json
+++ b/test/treeshake/multimain/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "treeshake",
+  "main": "main.js",
+  "version": "1.0.0"
+}

--- a/test/treeshake/multimain/prod1.html
+++ b/test/treeshake/multimain/prod1.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+<script src="dist/bundles/treeshake/main1.js"></script>
+</body>
+</html>


### PR DESCRIPTION
When the BuildOption `treeShaking: false` is provided, also disable
client-side tree shaking by setting the `treeShaking: false` config on
the Loader.

Fixes #1058