### PR TITLE
Enable tree-shaking ES modules only imported by non-ES modules

### DIFF
--- a/lib/graph/treeshake.js
+++ b/lib/graph/treeshake.js
@@ -112,9 +112,17 @@ function loadFromGraph(getNode) {
 					}
 				}
 
+				let code = '';
+
+				if(node) {
+					// Add deps as regular imports
+					for(let specifier of node.load.metadata.deps) {
+						code += `import "${specifier}";\n`;
+					}
+				}
+
 				// Expose named exports so that dependant modules will tree-shake properly.
 				if(needToExport.size) {
-					let code = '';
 					for(let exp of needToExport) {
 						if(exp === "default") {
 							code += "export default {};\n";
@@ -122,19 +130,18 @@ function loadFromGraph(getNode) {
 							code += `export let ${exp} = {};\n`;
 						}
 					}
-
-					return code;
 				} else {
 					// Prevent tree shaking modules that are side-effectual like CSS
 					if(sideEffectualModule(node)) {
-						return `
+						code += `
 							export function one() {window.ONE = {}};
 							one();
 						`.trim();
+					} else {
+						code += "export default {}";
 					}
-
-					return "export default {}";
 				}
+				return code;
 			}
 
 			return source.node(node);

--- a/lib/graph/treeshake.js
+++ b/lib/graph/treeshake.js
@@ -116,8 +116,10 @@ function loadFromGraph(getNode) {
 
 				if(node) {
 					// Add deps as regular imports
-					for(let specifier of node.load.metadata.deps) {
-						code += `import "${specifier}";\n`;
+					for(let i = 0; i < node.load.metadata.deps.length; i++) {
+						let specifier = node.load.metadata.deps[i];
+						code += `import * as dep${i} from "${specifier}";\n`;
+						code += `global.someFunction(dep${i}.default);\n`;
 					}
 				}
 

--- a/test/tree_shaking_test.js
+++ b/test/tree_shaking_test.js
@@ -126,6 +126,14 @@ describe("Tree-shaking", function(){
 				assert.equal(connect.didFail, true, "marked as failed");
 			});
 		});
+
+		describe.only("ES modules imported by CommonJS modules", function() {
+			it("Tree-shakes their ES module dependencies", function() {
+				let mod = app.dep5dep5AnotherESModule;
+				assert.equal(typeof mod.mainThing, "function", "Kept the used export");
+				assert.equal(typeof mod.another, "undefined", "Removed the unused export");
+			});
+		});
 	});
 
 	describe("treeShaking: false", function(){

--- a/test/tree_shaking_test.js
+++ b/test/tree_shaking_test.js
@@ -127,7 +127,7 @@ describe("Tree-shaking", function(){
 			});
 		});
 
-		describe.only("ES modules imported by CommonJS modules", function() {
+		describe("ES modules imported by CommonJS modules", function() {
 			it("Tree-shakes their ES module dependencies", function() {
 				let mod = app.dep5dep5AnotherESModule;
 				assert.equal(typeof mod.mainThing, "function", "Kept the used export");

--- a/test/treeshake/basics/main.js
+++ b/test/treeshake/basics/main.js
@@ -53,7 +53,8 @@ export default function(){
 		steal.import("dep4/other"),
 		steal.import("dep4/and-another"),
 		steal.import("~/from-exports"),
-		shouldFail
+		shouldFail,
+		steal.import("dep5/another-es-module")
 	]);
 
 	return p
@@ -64,7 +65,8 @@ export default function(){
 		dep4Other,
 		dep4AndAnother,
 		fromExports,
-		canConnect
+		canConnect,
+		dep5dep5AnotherESModule
 	]) => {
 		return {
 			anon,
@@ -75,7 +77,8 @@ export default function(){
 			dep4AndAnother,
 			fromExports,
 			dep5,
-			canConnect
+			canConnect,
+			dep5dep5AnotherESModule
 		};
 	});
 };

--- a/test/treeshake/basics/node_modules/dep5/another-es-module.js
+++ b/test/treeshake/basics/node_modules/dep5/another-es-module.js
@@ -1,0 +1,8 @@
+export function mainThing() {
+	
+}
+
+// This isn't used. This should be tree shaken.
+export function another() {
+
+}

--- a/test/treeshake/basics/node_modules/dep5/es-module.js
+++ b/test/treeshake/basics/node_modules/dep5/es-module.js
@@ -1,0 +1,5 @@
+import { another, mainThing } from "./another-es-module";
+
+window.mainThing = mainThing;
+
+// Notice that I do not use `another`

--- a/test/treeshake/basics/node_modules/dep5/main.js
+++ b/test/treeshake/basics/node_modules/dep5/main.js
@@ -1,3 +1,5 @@
+require("./es-module");
+
 exports.doStuff = function(){
 	return "worked";
 };


### PR DESCRIPTION
This fixes #1068.

While we do not tree shake non-ES modules, we should take their dependencies into consideration so that they will be treeshaken, in case they are not imported by another ES module.