### PR TITLE
Make bundle globs work with the modlet pattern

### DIFF
--- a/lib/loader/find_bundle.js
+++ b/lib/loader/find_bundle.js
@@ -34,20 +34,31 @@ function findBundles(loader) {
 
 	var pattern = [];
 	if (globs.length > 0) {
+		var out = [];
+
 		pattern = globs.map(function (bundlePattern) {
 			return substitute(bundlePattern, loader);
 		});
 
-		bundles = glob(pattern, Object.assign({}, globbyOptions)).map(function (bundle) {
-			bundle = minusJS(bundle);
-			if(loader.npmContext) {
-				var app = loader.npmContext.pkgInfo[0];
-				bundle = app.name + "/" + bundle;
-			}
-			return bundle;
+		pattern = groupPatterns(pattern);
+
+		pattern.forEach(pattern => {
+			var trailingSlash = typeof pattern === "string" && pattern.endsWith("/");
+
+			bundles = glob(pattern, Object.assign({}, globbyOptions)).forEach(function (bundle) {
+				bundle = minusJS(bundle);
+				if(trailingSlash && !isModlet(bundle)) {
+					return;
+				}
+				if(loader.npmContext) {
+					var app = loader.npmContext.pkgInfo[0];
+					bundle = app.name + "/" + bundle;
+				}
+				out.push(bundle);
+			});
 		});
 
-		return [].concat(plain, bundles);
+		return [].concat(plain, out);
 
 	} else {
 		return plain;
@@ -60,6 +71,10 @@ function minusJS(name) {
 	return idx === -1 ? name : name.substr(0, idx);
 }
 
+function isModlet(name) {
+	return /\/(.+)\/\1$/.test(name);
+}
+
 function startsWith(prefix, path) {
 	return path.substr(0,prefix.length) === prefix;
 }
@@ -70,6 +85,24 @@ function split(bundle, plain, globs) {
 	}else{
 		plain.push(bundle);
 	}
+}
+
+function groupPatterns(pattern) {
+	var current, last, i = 0, out = [];
+	while(i < pattern.length) {
+		current = pattern[i];
+
+		if(last && current[0] === "!") {
+			out.pop();
+			out.push([last, current]);
+		} else {
+			out.push(current);
+		}
+
+		last = current;
+		i++;
+	}
+	return out;
 }
 
 function substitute(bundle, loader) {

--- a/test/bundle/pages/home/home-test.js
+++ b/test/bundle/pages/home/home-test.js
@@ -1,0 +1,1 @@
+module.exports = "test";

--- a/test/bundle/pages/home/home.js
+++ b/test/bundle/pages/home/home.js
@@ -1,0 +1,2 @@
+
+module.exports = "home";

--- a/test/bundle_test.js
+++ b/test/bundle_test.js
@@ -26,6 +26,31 @@ describe("find bundle", function () {
 			'app_d'
 		], bundles);
 	});
+
+	it("wildcard with extension", function() {
+		fakeLoader["bundle"] = ["pages/*.component"];
+		var bundles = findbundle(fakeLoader);
+		assert.deepEqual([
+			'pages/cart.component',
+		], bundles);
+	});
+
+	it("the steal convention trailing slash", function() {
+		fakeLoader["bundle"] = ["pages/**/"];
+		var bundles = findbundle(fakeLoader);
+		assert.deepEqual([
+			'pages/home/home',
+		], bundles);
+	});
+
+	it("trailing slash and wildcard extension", function() {
+		fakeLoader["bundle"] = ["pages/**/", "pages/*.component"];
+		var bundles = findbundle(fakeLoader);
+		assert.deepEqual([
+			'pages/home/home',
+			'pages/cart.component'
+		], bundles);
+	});
 });
 
 describe("bundle", function () {
@@ -139,7 +164,3 @@ describe("bundle", function () {
 	});
 
 });
-
-
-
-

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -12,7 +12,7 @@ exports.find = function(browser, property, callback, done){
 		} else if(new Date() - start < 2000){
 			setTimeout(check, 20);
 		} else {
-			done("failed to find "+property+" in "+browser.window.location.href);
+			done(new Error("failed to find "+property+" in "+browser.window.location.href));
 		}
 	};
 	check();

--- a/test/multibuild_test.js
+++ b/test/multibuild_test.js
@@ -1507,6 +1507,7 @@ describe("multi build", function(){
 
 
 		it("should not include src/dep and jqueryt into the bundled file", function(done){
+			this.timeout(15000);
 			setup(function(error) {
 				if (error) {
 					return done(error);
@@ -1529,11 +1530,18 @@ describe("multi build", function(){
 					assert.equal(data.loader.envs['window-production'].map.jqueryt, '@empty', 'ignore modules must declare as @empty');
 
 					open("test/bundle_false/prod.html",function(browser, close){
+						var complete = 0;
+						var findDone = function() {
+							complete++;
+							if(complete === 2) {
+								close();
+							}
+						};
 
 						find(browser,"MODULE", function(module){
-							//assert.ok(module);
 							assert.equal(typeof module.name, "undefined", "depending Module shouldn't have been loaded");
-						}, close);
+							findDone();
+						}, findDone);
 
 						find(browser,"$", function(jqueryt){
 							// jqueryt is mapped to @empty
@@ -1541,10 +1549,11 @@ describe("multi build", function(){
 								var jversion = false;
 							try{
 								jversion = jqueryt.fn.version;
-							}catch(e){}
+							} catch(e) {}
+
 							assert.strictEqual(jversion, false, "jqueryt Module shouldn't have been loaded");
-							close();
-						}, close);
+							findDone();
+						}, findDone);
 
 					}, done);
 				}).catch(done);


### PR DESCRIPTION
This makes it so the following can be used:

```json
"bundle": [
  "pages/**/"
]
```

Which will find modules like:

- pages/home/home
- pages/cart/cart

But will not pick up

- pages/cart/cart-test