### PR TITLE
Make sure all side-effectual deps remain in tree

### DIFF
--- a/lib/graph/treeshake.js
+++ b/lib/graph/treeshake.js
@@ -92,7 +92,7 @@ function loadFromGraph(getNode, data) {
 			if(notESModule(node)) {
 				let needToExport = new Set();
 				let dependants = (node && getDependants(data.graph, node.load.name)) || [];
-
+				
 				// Determine what to export by looking at dependants imports
 				for(let depName of dependants) {
 					let localNode = getNode(depName);
@@ -105,10 +105,20 @@ function loadFromGraph(getNode, data) {
 							continue;
 						}
 
-						let imported = importNames[impSource] || [];
-						imported.forEach(imported => {
-							needToExport.add(imported);
-						});
+						let imported = importNames[impSource];
+
+						if(imported) {
+							if(imported.length) {
+								imported.forEach(imported => {
+									needToExport.add(imported);
+								});
+							}
+							// This is a side-effectual import
+							// import 'dep';
+							else {
+								node.load.metadata.importedForSideEffect = true;
+							}
+						}
 					}
 				}
 
@@ -154,7 +164,8 @@ function loadFromGraph(getNode, data) {
 function sideEffectualModule(node) {
 	if(node) {
 		let md = node.load.metadata;
-		return md.buildType === "css" || md.format === "global";
+		return md.buildType === "css" || md.format === "global" ||
+			md.importedForSideEffect;
 	}
 	return false;
 }

--- a/test/tree_shaking_test.js
+++ b/test/tree_shaking_test.js
@@ -95,6 +95,8 @@ describe("Tree-shaking", function(){
 						"Includes an ES module with needed side effects.");
 					assert.equal(browser.window.DEP3_SIDE_EFFECT2, true,
 						"Includes a global module with needed side effects.");
+					assert.equal(browser.window.DEP3_SIDE_EFFECT3, true,
+						"Includes a CJS module with needed side effects.");
 				});
 
 				it("Works when the dependency is CSS", function(){

--- a/test/treeshake/basics/main.js
+++ b/test/treeshake/basics/main.js
@@ -13,6 +13,7 @@ import steal from "@steal";
 // Importing a module for its side effects
 import "dep3";
 import "dep3/global";
+import "dep3/cjs";
 
 // CSS
 import "./styles.css";

--- a/test/treeshake/basics/node_modules/dep3/cjs.js
+++ b/test/treeshake/basics/node_modules/dep3/cjs.js
@@ -1,0 +1,4 @@
+
+window.DEP3_SIDE_EFFECT3 = true;
+
+module.exports = {};

--- a/test/treeshake/basics/node_modules/dep5/two.js
+++ b/test/treeshake/basics/node_modules/dep5/two.js
@@ -1,0 +1,3 @@
+exports.get = function(){
+	return "worked";
+};


### PR DESCRIPTION
Whenever a side-effectual import is used like:

```js
import "dep";
```

Then `dep` remains in the tree. This is only true of ES modules.