### PR TITLE
chore: pin rollup-plugin-commonjs to 9.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "pdenodeify": "^0.1.0",
     "prettier": "1.12.0",
     "pump": "^3.0.0",
-    "rollup-plugin-commonjs": "9.3.2",
+    "rollup-plugin-commonjs": "<=9.3.2",
     "steal": "^2.2.0",
     "steal-bundler": "^0.3.6",
     "steal-parse-amd": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "pdenodeify": "^0.1.0",
     "prettier": "1.12.0",
     "pump": "^3.0.0",
-    "rollup-plugin-commonjs": "^9.1.3",
+    "rollup-plugin-commonjs": "9.3.2",
     "steal": "^2.2.0",
     "steal-bundler": "^0.3.6",
     "steal-parse-amd": "^1.0.0",


### PR DESCRIPTION
The `rollup-plugin-commonjs` plugin breaks steal tools builds after 9.3.2, so this pins it.

We can find a fix after and unpin this.