### PR TITLE
Update CJS_PROXY_PREFIX

### DIFF
--- a/lib/bundle/concat_source_es.js
+++ b/lib/bundle/concat_source_es.js
@@ -7,7 +7,7 @@ const removeActiveSourceKeys = require("../node/remove_active_source_keys");
 const rollup = require("steal-rollup");
 
 const moduleNameFromSpecifier = dependencyResolver.moduleNameFromSpecifier;
-const CJS_PROXY_PREFIX = '\0commonjs-proxy:';
+const CJS_PROXY_PREFIX = '\0commonjs-proxy-';
 
 module.exports = function(bundle, options) {
 	let removeDevelopmentCode = options.removeDevelopmentCode;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "pdenodeify": "^0.1.0",
     "prettier": "1.12.0",
     "pump": "^3.0.0",
-    "rollup-plugin-commonjs": "<=9.3.2",
+    "rollup-plugin-commonjs": "^9.3.4",
     "steal": "^2.2.0",
     "steal-bundler": "^0.3.6",
     "steal-parse-amd": "^1.0.0",


### PR DESCRIPTION
Rollup's CommonJS plugin changed the prefix that it uses for proxy files, since it was having problems with colons being used in file names.

This PR updates the prefix to match what the latest version of Rollup uses (colon replaced with hyphen).

Fixes #1125.

See https://github.com/rollup/rollup-plugin-commonjs/pull/371 for more info.