### PR TITLE
Fix race condition where last format transform overrides previous ones

### DIFF
--- a/lib/build/transform.js
+++ b/lib/build/transform.js
@@ -143,31 +143,33 @@ var transformImport = function(config, transformOptions){
 				winston.debug("+ %s", node.load.name);
 			});
 
-			return Promise.resolve()
-			.then(function(){
+			return new Promise(function(resolve, reject) {
 				var concatOptions = {
 					excludePlugins: options.format === "global",
 					sourceProp: "activeSource",
 					format: options.concatFormat,
 					removeDevelopmentCode: options.removeDevelopmentCode
 				};
-				return concatSource(bundle, concatOptions);
-			})
-			.then(function(){
-				if(options.sourceMaps) {
-					addSourceMapUrl(bundle);
-				}
 
-				return bundle;
-			})
-			.then(function(bundle) {
-				// #### minify
-				if(options.minify) {
-					winston.debug('Minifying...');
-					return minify(bundle);
-				} else {
-					return bundle.source;
-				}
+				return concatSource(bundle, concatOptions)
+					.then(function(){
+						if(options.sourceMaps) {
+							addSourceMapUrl(bundle);
+						}
+		
+						return bundle;
+					})
+					.then(function(bundle) {
+						// #### minify
+						if(options.minify) {
+							winston.debug('Minifying...');
+							return minify(bundle);
+						} else {
+							return bundle.source;
+						}
+					})
+					.then(resolve)
+					.catch(reject);
 			});
 		};
 
@@ -176,10 +178,7 @@ var transformImport = function(config, transformOptions){
 		transform.loader = data.loader;
 		transform.data = data;
 		return transform;
-
-
 	});
-
 };
 
 

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "test": "npm run jshint && npm run mocha && npm run test:browser && npm run test:slim-worker-single && npm run test:slim-worker-progressive && npm run test:exports-worker",
     "test:browser": "npm run worker-test-build && testee test/browser/test.html --browsers firefox --reporter Spec",
     "worker-test-build": "node bin/steal build --main worker --config test/browser/webworker/stealconfig.js --bundle-steal --quiet",
-    "mocha": "node test/test.js",
+    "mocha": "mocha test/test.js",
     "jshint": "jshint lib/ Gruntfile.js --config",
     "coverage": "istanbul cover _mocha -- test/test --timeout 600000",
     "coverage:upload": "istanbul cover _mocha --report lcovonly -- test/test --timeout 600000 && cat ./coverage/lcov.info | ./node_modules/coveralls-send/bin/coveralls.js",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "test": "npm run jshint && npm run mocha && npm run test:browser && npm run test:slim-worker-single && npm run test:slim-worker-progressive && npm run test:exports-worker",
     "test:browser": "npm run worker-test-build && testee test/browser/test.html --browsers firefox --reporter Spec",
     "worker-test-build": "node bin/steal build --main worker --config test/browser/webworker/stealconfig.js --bundle-steal --quiet",
-    "mocha": "mocha test/test.js",
+    "mocha": "node test/test.js",
     "jshint": "jshint lib/ Gruntfile.js --config",
     "coverage": "istanbul cover _mocha -- test/test --timeout 600000",
     "coverage:upload": "istanbul cover _mocha --report lcovonly -- test/test --timeout 600000 && cat ./coverage/lcov.info | ./node_modules/coveralls-send/bin/coveralls.js",

--- a/test/test.js
+++ b/test/test.js
@@ -1,72 +1,51 @@
-var Mocha = require("mocha");
-var path = require("path");
+require("./recycle_test");
 
-var mocha = new Mocha();
+// Unit tests
+require("./clean_address_test");
+require("./clean_test");
+require("../lib/bundle/bundle_test");
+require("./cli/cmd_build_test");
+require("./cli/cmd_bundle_test");
+require("./cli/cmd_build_int_test");
+require("./cli/cmd_transform_test");
+require("./cli/make_steal_config_test");
+require("./cli/cmd_export_test");
+require("./cli/make_outputs_test");
+require("./cli/cmd_live_test");
+require("./get_es_module_imports_test");
+require("./cli/make_build_options_test");
+require("./slim_build_conditionals_test");
+require("./minify_js_test");
+require("./tree_shaking_test");
 
-var testFiles = [
-	"./recycle_test",
+// Integration tests
+require("./test_cli");
+require("./test_live");
+require("./bundle_name_test");
+require("./dependencygraph_test");
+require("./bundle_test");
+require("./order_test");
 
-	// Unit tests
-	"./clean_address_test",
-	"./clean_test",
-	"../lib/bundle/bundle_test",
-	"./cli/cmd_build_test",
-	"./cli/cmd_bundle_test",
-	"./cli/cmd_build_int_test",
-	"./cli/cmd_transform_test",
-	"./cli/make_steal_config_test",
-	"./cli/cmd_export_test",
-	"./cli/make_outputs_test",
-	"./cli/cmd_live_test",
-	"./get_es_module_imports_test",
-	"./cli/make_build_options_test",
-	"./slim_build_conditionals_test",
-	"./minify_js_test",
-	"./tree_shaking_test",
+require("./multibuild_test");
+require("./multi_main_build_test");
+require("./transform_test");
+require("./export_test");
+require("./export_global_js_test");
+require("./export_global_css_test");
+require("./export_standalone_test");
+require("./export_bundled_es_test");
+require("./continuous_test");
+require("./concat_test");
+require("./graph_stream_test");
+require("./transpile_test");
+require("./write_stream_test");
+require("./build_conditionals_test");
+require("./dev_bundle_build_test");
+require("./babel_presets_test");
+require("./babel_plugins_test");
+require("./slim_build_test");
+require("./slim_loader_size_test");
 
-	// Integration tests
-	"./test_cli",
-	"./test_live",
-	"./bundle_name_test",
-	"./dependencygraph_test",
-	"./bundle_test",
-	"./order_test",
-
-	"./multibuild_test",
-	"./multi_main_build_test",
-	"./transform_test",
-	"./export_test",
-	"./export_global_js_test",
-	"./export_global_css_test",
-	"./export_standalone_test",
-	"./export_bundled_es_test",
-	"./continuous_test",
-	"./concat_test",
-	"./graph_stream_test",
-	"./transpile_test",
-	"./write_stream_test",
-	"./build_conditionals_test",
-	"./dev_bundle_build_test",
-	"./babel_presets_test",
-	"./babel_plugins_test",
-	"./slim_build_test",
-	"./slim_loader_size_test",
-
-	// external steal-tools plugins
-	"./bundle_assets_test"
-	//"./serviceworker_test", skip for now
-];
-
-testFiles.forEach(function(file) {
-	mocha.addFile(path.join(__dirname, file + ".js"));
-});
-
-try {
-	mocha.run(function(failures) {
-		// exit with non-zero status if there were failures
-		process.exit(failures ? 1 : 0);
-	});
-} catch (error) {
-	console.error(error);
-	process.exit(1);
-}
+// external steal-tools plugins
+require("./bundle_assets_test");
+//require("./serviceworker_test"); skip for now

--- a/test/test.js
+++ b/test/test.js
@@ -1,51 +1,72 @@
-require("./recycle_test");
+var Mocha = require("mocha");
+var path = require("path");
 
-// Unit tests
-require("./clean_address_test");
-require("./clean_test");
-require("../lib/bundle/bundle_test");
-require("./cli/cmd_build_test");
-require("./cli/cmd_bundle_test");
-require("./cli/cmd_build_int_test");
-require("./cli/cmd_transform_test");
-require("./cli/make_steal_config_test");
-require("./cli/cmd_export_test");
-require("./cli/make_outputs_test");
-require("./cli/cmd_live_test");
-require("./get_es_module_imports_test");
-require("./cli/make_build_options_test");
-require("./slim_build_conditionals_test");
-require("./minify_js_test");
-require("./tree_shaking_test");
+var mocha = new Mocha();
 
-// Integration tests
-require("./test_cli");
-require("./test_live");
-require("./bundle_name_test");
-require("./dependencygraph_test");
-require("./bundle_test");
-require("./order_test");
+var testFiles = [
+	"./recycle_test",
 
-require("./multibuild_test");
-require("./multi_main_build_test");
-require("./transform_test");
-require("./export_test");
-require("./export_global_js_test");
-require("./export_global_css_test");
-require("./export_standalone_test");
-require("./export_bundled_es_test");
-require("./continuous_test");
-require("./concat_test");
-require("./graph_stream_test");
-require("./transpile_test");
-require("./write_stream_test");
-require("./build_conditionals_test");
-require("./dev_bundle_build_test");
-require("./babel_presets_test");
-require("./babel_plugins_test");
-require("./slim_build_test");
-require("./slim_loader_size_test");
+	// Unit tests
+	"./clean_address_test",
+	"./clean_test",
+	"../lib/bundle/bundle_test",
+	"./cli/cmd_build_test",
+	"./cli/cmd_bundle_test",
+	"./cli/cmd_build_int_test",
+	"./cli/cmd_transform_test",
+	"./cli/make_steal_config_test",
+	"./cli/cmd_export_test",
+	"./cli/make_outputs_test",
+	"./cli/cmd_live_test",
+	"./get_es_module_imports_test",
+	"./cli/make_build_options_test",
+	"./slim_build_conditionals_test",
+	"./minify_js_test",
+	"./tree_shaking_test",
 
-// external steal-tools plugins
-require("./bundle_assets_test");
-//require("./serviceworker_test"); skip for now
+	// Integration tests
+	"./test_cli",
+	"./test_live",
+	"./bundle_name_test",
+	"./dependencygraph_test",
+	"./bundle_test",
+	"./order_test",
+
+	"./multibuild_test",
+	"./multi_main_build_test",
+	"./transform_test",
+	"./export_test",
+	"./export_global_js_test",
+	"./export_global_css_test",
+	"./export_standalone_test",
+	"./export_bundled_es_test",
+	"./continuous_test",
+	"./concat_test",
+	"./graph_stream_test",
+	"./transpile_test",
+	"./write_stream_test",
+	"./build_conditionals_test",
+	"./dev_bundle_build_test",
+	"./babel_presets_test",
+	"./babel_plugins_test",
+	"./slim_build_test",
+	"./slim_loader_size_test",
+
+	// external steal-tools plugins
+	"./bundle_assets_test"
+	//"./serviceworker_test", skip for now
+];
+
+testFiles.forEach(function(file) {
+	mocha.addFile(path.join(__dirname, file + ".js"));
+});
+
+try {
+	mocha.run(function(failures) {
+		// exit with non-zero status if there were failures
+		process.exit(failures ? 1 : 0);
+	});
+} catch (error) {
+	console.error(error);
+	process.exit(1);
+}


### PR DESCRIPTION
The transform function resolved by `transformInput` was handling
the bundle concatenation to the event loop too early, causing future
transforms (sharing the same graph) to reset the activeSourceKeys
object -where the result of transpiled graphs are kept- before the bundle
was concatenated.

This meant the last transform would override all of the previous ones,
instead of doing `return Promise.resolve().then(concatenateBundle)`, this
commit creates a new promise that runs `concatenateBundle` right away
instead of waiting for the next tick (and opening the window from future
transforms to mutate the graph).

Closes #1139