### PR TITLE
Add .git folder to npmignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .tmp*
 .idea
+.git
 dist
 coverage
 package-lock.json

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@
 Gruntfile.js
 .travis.yml
 appveyor.yml
+.git


### PR DESCRIPTION
In theory this should not be necessary since it is supposed to be
ignored by default but it somehow made it to the tarfile published
by npm.