### PR TITLE
Support es-module default exports in babel plugins

### DIFF
--- a/lib/process_babel_plugins.js
+++ b/lib/process_babel_plugins.js
@@ -70,6 +70,11 @@ function processPlugins(baseURL, plugins) {
 			// load the plugin!
 			var pluginFn = require(npmPluginNameOrPath);
 
+			// check for ESM default export
+			if (pluginFn.default) {
+				pluginFn = pluginFn.default;
+			}
+
 			if (_.isString(plugin)) {
 				normalized.push(pluginFn);
 			}


### PR DESCRIPTION
This adds support for babel plugins that use ES modules that use the default export.   The problem was that somewhere in this [plugins array](https://github.com/stealjs/steal-tools/blob/c8baaf1cbb2141353dd17fa29ac1a46152f2895b/lib/process_babel_plugins.js#L61) the module paths were being replaced by the `require`d modules.  An ES module would become replaced by `{ isEsModule: true, default: Fn }`, which wouldn't pass the `isPluginFunction(plugin)` conditional on subsequent calls to [processPlugins](https://github.com/stealjs/steal-tools/blob/c8baaf1cbb2141353dd17fa29ac1a46152f2895b/lib/process_babel_plugins.js#L54).

The 3-line change in this PR just check for the presence of `pluginFn.default` and use that as `pluginFn`.